### PR TITLE
allow more specific match for what should be visualised

### DIFF
--- a/autobuild/build_util.py
+++ b/autobuild/build_util.py
@@ -79,8 +79,15 @@ def execute_notebooks_in_folder(
     print(f"Found {len(files)} notebooks")
 
     for file in sorted(files):
-        if visualise_list is not None and file.stem not in visualise_list:
-            continue
+        if visualise_list is not None:
+            without_suffix = str(file.with_suffix(""))
+            if not any(
+                map(
+                    without_suffix.endswith,
+                    visualise_list,
+                )
+            ):
+                continue
         if file.stem not in no_run_list:
             execute_notebook(file)
 


### PR DESCRIPTION
The contents of visualise_notebooks can now be more specific. If the path to a file (without a suffix) ends with a specified item then it is visualised.

For example
one/two/three.yaml in the autofit project could be specified in three ways.

```yaml
autofit:
  - three
  - two/three
  - one/two/three
