### PR TITLE
call push as well to ensure that the version dunder is updated on git during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -448,6 +448,7 @@ jobs:
         git tag -m "Release $VERSION" -a "$VERSION"
         PAT="${{ secrets[matrix.project.pat] }}"
         git remote set-url --push origin "https://$PAT@github.com/${{ matrix.project.repository }}.git"
+        git push
         git push --tags
     - name: Build
       if: "${{ github.event.inputs.skip_release != 'true' }}"


### PR DESCRIPTION
Should resolve #6
