### PR TITLE
Remove UltraNest and PySwarms from no_run.yaml

### DIFF
--- a/autobuild/config/no_run.yaml
+++ b/autobuild/config/no_run.yaml
@@ -2,13 +2,8 @@ autofit:
 - GetDist # Cant get it to install, even in optional requirements.
 - Zeus # Test Model Iniitalization no good.
 - ZeusPlotter # Test Model Iniitalization no good.
-- UltraNestPlotter # Test Model Iniitalization no good.
 - DynestyPlotter # Test Model Iniitalization no good.
 - start_point # bug https://github.com/rhayes777/PyAutoFit/issues/1017
-- searches/mle/PySwarmsGlobal # PySwarms does not support JAX.
-- searches/mle/PySwarmsLocal # PySwarms does not support JAX.
-- searches/nest/UltraNest # UltraNest does not support JAX.
-- plot/PySwarmsPlotter # PySwarms does not support JAX.
 autogalaxy:
 - tutorial_searches
 - gui/light_centre # GUI scripts cannot be run

--- a/test_results/autofit__plot__script.md
+++ b/test_results/autofit__plot__script.md
@@ -1,0 +1,35 @@
+# Test Report: autofit / plot (script)
+
+**5 scripts** | 1 failed | 1 passed | 3 skipped
+
+| Status | Count |
+|--------|-------|
+| failed | 1 |
+| passed | 1 |
+| skipped | 3 |
+
+## Failures
+
+### `/home/jammy/Code/PyAutoLabs/autofit_workspace/scripts/plot/EmceePlotter.py` — FAILED (2.3s)
+
+Command '['/home/jammy/venv/PyAuto/bin/python3', '/home/jammy/Code/PyAutoLabs/autofit_workspace/scripts/plot/EmceePlotter.py']' returned non-zero exit status 1.
+
+```
+Traceback (most recent call last):
+  File "/home/jammy/Code/PyAutoLabs/autofit_workspace/scripts/plot/EmceePlotter.py", line 156, in <module>
+    for walker_index in range(search_internal.get_log_prob().shape[1]):
+                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+AttributeError: 'NoneType' object has no attribute 'get_log_prob'
+```
+
+## Skipped
+
+| Script | Reason |
+|--------|--------|
+| `DynestyPlotter.py` | Test Model Iniitalization no good. |
+| `GetDist.py` | Cant get it to install, even in optional requirements. |
+| `ZeusPlotter.py` | Test Model Iniitalization no good. |
+
+## Passed
+
+- `/home/jammy/Code/PyAutoLabs/autofit_workspace/scripts/plot/NautilusPlotter.py` (1.8s)

--- a/test_results/autofit__searches__script.md
+++ b/test_results/autofit__searches__script.md
@@ -1,0 +1,24 @@
+# Test Report: autofit / searches (script)
+
+**8 scripts** | 6 passed | 2 skipped
+
+| Status | Count |
+|--------|-------|
+| passed | 6 |
+| skipped | 2 |
+
+## Skipped
+
+| Script | Reason |
+|--------|--------|
+| `Zeus.py` | Test Model Iniitalization no good. |
+| `start_point.py` | bug https://github.com/rhayes777/PyAutoFit/issues/1017 |
+
+## Passed
+
+- `/home/jammy/Code/PyAutoLabs/autofit_workspace/scripts/searches/mcmc/Emcee.py` (2.7s)
+- `/home/jammy/Code/PyAutoLabs/autofit_workspace/scripts/searches/mle/Drawer.py` (2.6s)
+- `/home/jammy/Code/PyAutoLabs/autofit_workspace/scripts/searches/mle/LBFGS.py` (2.1s)
+- `/home/jammy/Code/PyAutoLabs/autofit_workspace/scripts/searches/nest/DynestyDynamic.py` (1.6s)
+- `/home/jammy/Code/PyAutoLabs/autofit_workspace/scripts/searches/nest/DynestyStatic.py` (1.6s)
+- `/home/jammy/Code/PyAutoLabs/autofit_workspace/scripts/searches/nest/Nautilus.py` (1.6s)


### PR DESCRIPTION
## Summary
Remove no_run.yaml entries and test report rows for UltraNest and PySwarms scripts that have been deleted from autofit_workspace.

## Scripts Changed
- `autobuild/config/no_run.yaml` — removed 5 skip entries for deleted scripts
- `test_results/autofit__plot__script.md` — removed PySwarmsPlotter/UltraNestPlotter rows
- `test_results/autofit__searches__script.md` — removed PySwarmsGlobal/PySwarmsLocal/UltraNest rows

## Upstream PR
https://github.com/rhayes777/PyAutoFit/pull/1191

## Test Plan
- [ ] Build pipeline succeeds without the removed scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)