### PR TITLE
Cap script timeout at 60s + live streaming output

### DIFF
--- a/autobuild/build_util.py
+++ b/autobuild/build_util.py
@@ -9,7 +9,7 @@ import traceback
 from pathlib import Path
 from typing import List
 
-TIMEOUT_SECS = 36000
+TIMEOUT_SECS = 60
 BUILD_PATH = Path(__file__).parent
 
 BUILD_PYTHON_INTERPRETER = os.environ.get("BUILD_PYTHON_INTERPRETER", "python3")
@@ -97,9 +97,6 @@ def execute_notebook(f, report=None, env=None):
                 text=True,
                 env=env,
             )
-            print(result.stdout)
-            if result.stderr:
-                print(result.stderr, file=sys.stderr)
         else:
             subprocess.run(
                 ["jupyter", "nbconvert", "--to", "notebook", "--execute", "--output", f, f],
@@ -221,9 +218,6 @@ def execute_script(f, report=None, env=None):
                 text=True,
                 env=env,
             )
-            print(result.stdout)
-            if result.stderr:
-                print(result.stderr, file=sys.stderr)
         else:
             subprocess.run(
                 args,

--- a/autobuild/run_all.py
+++ b/autobuild/run_all.py
@@ -58,6 +58,7 @@ def run_workspace(name, workspace_dir, project, results_dir, python):
     import os
     env = os.environ.copy()
     env["BUILD_PYTHON_INTERPRETER"] = python
+    env["PYTHONUNBUFFERED"] = "1"
 
     for directory in directories:
         print(f"\n  Running {name} / scripts/{directory} ...")


### PR DESCRIPTION
## Summary

- Lower `TIMEOUT_SECS` from `36000` (10h!) to `60` so a single hung script can no longer block a full mega-run
- Remove the verbose `print(result.stdout)` / `print(result.stderr)` dumps in `execute_script` and `execute_notebook` so the console stays one-line-per-script
- Set `PYTHONUNBUFFERED=1` in `run_all.py` before launching per-directory subprocesses so live `PASS/FAIL/TIMEOUT` lines aren't block-buffered through the pipe

## Test plan

- [x] Sanity check on a single directory: `run_python.py autolens multi --report-dir /tmp/test_results_check` — live stream confirmed
- [x] Full mega-run via `run_all.py` — all 476 scripts stream live, timeouts kick in at 60s, run completes in ~35 min