### PR TITLE
Surface SLOW-skipped scripts with persistent warning

### DIFF
--- a/autobuild/aggregate_results.py
+++ b/autobuild/aggregate_results.py
@@ -185,6 +185,31 @@ def generate_markdown(report: dict) -> str:
     lines.append(f"**Status: {status}**")
     lines.append("")
 
+    # Slow-skipped scripts — surface at the top so they can't be missed
+    slow_skips = report.get("slow_skips") or []
+    if slow_skips:
+        lines.append("## Slow-Skipped Scripts (needs performance fix)")
+        lines.append("")
+        lines.append(
+            f"**{len(slow_skips)} script(s)** are being skipped because they exceed "
+            "the 60s per-script timeout cap. These are NOT permanent skips — they "
+            "need the underlying performance issue fixed and the `SLOW` marker "
+            "removed from the workspace's `config/build/no_run.yaml`."
+        )
+        lines.append("")
+        lines.append("| Workspace | Script | Marked | Age | Reason |")
+        lines.append("|-----------|--------|--------|-----|--------|")
+        for s in sorted(slow_skips, key=lambda x: (x["workspace"], x["pattern"])):
+            date_str = s.get("marked_date") or "unknown"
+            age = s.get("age_days")
+            age_str = f"{age}d" if age is not None else "—"
+            if s.get("is_stale"):
+                age_str += " **STALE**"
+            lines.append(
+                f"| {s['workspace']} | `{s['pattern']}` | {date_str} | {age_str} | {s['reason']} |"
+            )
+        lines.append("")
+
     # Summary
     s = report.get("summary", {})
     lines.append("## Summary")

--- a/autobuild/run_all.py
+++ b/autobuild/run_all.py
@@ -100,6 +100,16 @@ def main():
     print(f"Results directory: {results_dir}")
     print(f"Workspaces: {', '.join(workspaces)}")
 
+    from slow_skip_check import find_slow_skips, format_warning_banner, format_report_section
+    ws_dirs_for_scan = [
+        PYAUTOBASE / WORKSPACES[k][0]
+        for k in workspaces
+        if (PYAUTOBASE / WORKSPACES[k][0]).exists()
+    ]
+    slow_skips = find_slow_skips(ws_dirs_for_scan)
+    if slow_skips:
+        print(format_warning_banner(slow_skips))
+
     for ws_key in workspaces:
         ws_name, project = WORKSPACES[ws_key]
         ws_dir = PYAUTOBASE / ws_name
@@ -126,6 +136,7 @@ def main():
     from aggregate_results import aggregate, generate_markdown
 
     report = aggregate(results_dir)
+    report["slow_skips"] = [s.to_dict() for s in slow_skips]
 
     import json
     with open(results_dir / "report.json", "w") as f:
@@ -155,6 +166,9 @@ def main():
         print(f"\n{len(failures)} failure(s) — see {md_path}")
     else:
         print(f"\nAll tests passed! Full report: {md_path}")
+
+    if slow_skips:
+        print(format_warning_banner(slow_skips))
 
     sys.exit(1 if failures else 0)
 

--- a/autobuild/slow_skip_check.py
+++ b/autobuild/slow_skip_check.py
@@ -1,0 +1,182 @@
+"""
+Scan workspace no_run.yaml files for entries tagged as SLOW-skips and
+surface them so they cannot be silently forgotten.
+
+A SLOW-skip entry has an inline comment of the form:
+
+    - scripts/foo/bar.py # SLOW 2026-04-10 - reason text
+
+The date is optional (entries with just `# SLOW - reason` are still picked
+up, but will report `date unknown`). Anything else in no_run.yaml is treated
+as a permanent skip and ignored by this scanner.
+"""
+
+import dataclasses
+import datetime
+import re
+from pathlib import Path
+from typing import List, Optional
+
+SLOW_RE = re.compile(
+    r"^\s*SLOW(?:\s+(\d{4}-\d{2}-\d{2}))?\s*-\s*(.*)$"
+)
+
+STALE_THRESHOLD_DAYS = 30
+
+
+@dataclasses.dataclass
+class SlowSkip:
+    workspace: str
+    pattern: str
+    reason: str
+    marked_date: Optional[datetime.date] = None
+
+    @property
+    def age_days(self) -> Optional[int]:
+        if self.marked_date is None:
+            return None
+        return (datetime.date.today() - self.marked_date).days
+
+    @property
+    def is_stale(self) -> bool:
+        age = self.age_days
+        return age is not None and age >= STALE_THRESHOLD_DAYS
+
+    def to_dict(self) -> dict:
+        return {
+            "workspace": self.workspace,
+            "pattern": self.pattern,
+            "reason": self.reason,
+            "marked_date": self.marked_date.isoformat() if self.marked_date else None,
+            "age_days": self.age_days,
+            "is_stale": self.is_stale,
+        }
+
+
+def _parse_entries(yaml_path: Path) -> List[tuple]:
+    """Return a list of (pattern, inline_comment_or_empty) from a no_run.yaml file.
+
+    We parse line-by-line rather than using PyYAML so we can recover the
+    inline comments (which PyYAML strips).
+    """
+    entries = []
+    for line in yaml_path.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("- "):
+            continue
+        entry = stripped[2:]
+        if "#" in entry:
+            pattern, comment = entry.split("#", 1)
+            entries.append((pattern.strip(), comment.strip()))
+        else:
+            entries.append((entry.strip(), ""))
+    return entries
+
+
+def find_slow_skips(workspace_dirs: List[Path]) -> List[SlowSkip]:
+    """Scan every workspace's config/build/no_run.yaml for SLOW-tagged entries."""
+    out: List[SlowSkip] = []
+    for ws_dir in workspace_dirs:
+        no_run = ws_dir / "config" / "build" / "no_run.yaml"
+        if not no_run.exists():
+            continue
+        for pattern, comment in _parse_entries(no_run):
+            m = SLOW_RE.match(comment)
+            if not m:
+                continue
+            date_str, reason = m.group(1), m.group(2).strip()
+            marked_date = None
+            if date_str:
+                try:
+                    marked_date = datetime.date.fromisoformat(date_str)
+                except ValueError:
+                    marked_date = None
+            out.append(SlowSkip(
+                workspace=ws_dir.name,
+                pattern=pattern,
+                reason=reason,
+                marked_date=marked_date,
+            ))
+    return out
+
+
+def format_warning_banner(slow_skips: List[SlowSkip]) -> str:
+    """Return a loud, hard-to-miss plain-text banner listing every SLOW-skip."""
+    if not slow_skips:
+        return ""
+
+    width = 72
+    bar = "=" * width
+    lines = [
+        "",
+        bar,
+        f"  WARNING: {len(slow_skips)} SLOW-SKIPPED SCRIPT(S) - needs performance fix",
+        bar,
+    ]
+
+    by_ws: dict = {}
+    for s in slow_skips:
+        by_ws.setdefault(s.workspace, []).append(s)
+
+    for ws in sorted(by_ws):
+        lines.append(f"  {ws}:")
+        for s in sorted(by_ws[ws], key=lambda x: x.pattern):
+            lines.append(f"    {s.pattern}")
+            if s.marked_date:
+                age = s.age_days
+                stale_tag = "  [STALE]" if s.is_stale else ""
+                lines.append(f"      marked {s.marked_date.isoformat()} ({age} days ago){stale_tag}")
+            else:
+                lines.append("      marked date unknown")
+            lines.append(f"      {s.reason}")
+        lines.append("")
+
+    lines.append(bar)
+    lines.append("  These scripts are skipped because they exceed the 60s per-script")
+    lines.append("  cap. Fix the performance issue and remove the SLOW marker from")
+    lines.append("  the workspace's config/build/no_run.yaml.")
+    lines.append(bar)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def format_report_section(slow_skips: List[SlowSkip]) -> str:
+    """Return a markdown section for inclusion in the aggregated report.md."""
+    if not slow_skips:
+        return ""
+    lines = [
+        "## Slow-Skipped Scripts (needs performance fix)",
+        "",
+        f"**{len(slow_skips)} script(s)** are being skipped because they exceed the 60s "
+        "per-script timeout cap. These are NOT permanent skips — they need the "
+        "underlying performance issue fixed and the `SLOW` marker removed from the "
+        "workspace's `config/build/no_run.yaml`.",
+        "",
+        "| Workspace | Script | Marked | Age | Reason |",
+        "|-----------|--------|--------|-----|--------|",
+    ]
+    for s in sorted(slow_skips, key=lambda x: (x.workspace, x.pattern)):
+        date_str = s.marked_date.isoformat() if s.marked_date else "unknown"
+        age_str = f"{s.age_days}d" if s.age_days is not None else "—"
+        if s.is_stale:
+            age_str += " **STALE**"
+        lines.append(f"| {s.workspace} | `{s.pattern}` | {date_str} | {age_str} | {s.reason} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    import sys
+    pyautobase = Path(__file__).resolve().parent.parent.parent
+    default_workspaces = [
+        pyautobase / name for name in (
+            "autofit_workspace",
+            "autogalaxy_workspace",
+            "autolens_workspace",
+            "autofit_workspace_test",
+            "autolens_workspace_test",
+        )
+    ]
+    targets = [Path(p) for p in sys.argv[1:]] or default_workspaces
+    skips = find_slow_skips(targets)
+    print(format_warning_banner(skips) or "No SLOW-skipped scripts found.")


### PR DESCRIPTION
## Summary

- New `SLOW <YYYY-MM-DD>` convention in workspace `no_run.yaml` distinguishes temporary performance-timeout skips from permanent ones (GUI, broken features, etc)
- New `autobuild/slow_skip_check.py` scans every target workspace's `no_run.yaml`, parses SLOW-tagged entries, and formats a loud warning banner + markdown section
- `run_all.py` now prints the banner at the start and end of every mega-run; entries older than 30 days get a `STALE` tag to escalate the nag
- Aggregated `report.md` gains a `Slow-Skipped Scripts` section at the top listing every slow-skipped script with workspace, pattern, date marked, age, and reason

Paired with workspace PRs that add the first 11 SLOW entries (autogalaxy, autolens, autolens_test).

## Test plan

- [x] Direct scanner test: 11 entries found across 3 workspaces, dates parsed correctly
- [x] Markdown section renders correctly in `generate_markdown`
- [x] Imports clean (run_all, aggregate_results, slow_skip_check)
- [ ] End-to-end `run_all.py` run with banner visible at start and end