### PR TITLE
Add NEEDS_FIX skip category alongside SLOW

### DIFF
--- a/autobuild/aggregate_results.py
+++ b/autobuild/aggregate_results.py
@@ -185,21 +185,18 @@ def generate_markdown(report: dict) -> str:
     lines.append(f"**Status: {status}**")
     lines.append("")
 
-    # Slow-skipped scripts — surface at the top so they can't be missed
-    slow_skips = report.get("slow_skips") or []
-    if slow_skips:
-        lines.append("## Slow-Skipped Scripts (needs performance fix)")
+    # Slow-skipped and needs-fix scripts — surface at the top so they
+    # can't be missed
+    def _render_tagged_section(title: str, intro: str, entries: list) -> None:
+        if not entries:
+            return
+        lines.append(title)
         lines.append("")
-        lines.append(
-            f"**{len(slow_skips)} script(s)** are being skipped because they exceed "
-            "the 60s per-script timeout cap. These are NOT permanent skips — they "
-            "need the underlying performance issue fixed and the `SLOW` marker "
-            "removed from the workspace's `config/build/no_run.yaml`."
-        )
+        lines.append(intro.format(n=len(entries)))
         lines.append("")
         lines.append("| Workspace | Script | Marked | Age | Reason |")
         lines.append("|-----------|--------|--------|-----|--------|")
-        for s in sorted(slow_skips, key=lambda x: (x["workspace"], x["pattern"])):
+        for s in sorted(entries, key=lambda x: (x["workspace"], x["pattern"])):
             date_str = s.get("marked_date") or "unknown"
             age = s.get("age_days")
             age_str = f"{age}d" if age is not None else "—"
@@ -209,6 +206,27 @@ def generate_markdown(report: dict) -> str:
                 f"| {s['workspace']} | `{s['pattern']}` | {date_str} | {age_str} | {s['reason']} |"
             )
         lines.append("")
+
+    _render_tagged_section(
+        title="## Slow-Skipped Scripts (needs performance fix)",
+        intro=(
+            "**{n} script(s)** are being skipped because they exceed the 60s "
+            "per-script timeout cap. These are NOT permanent skips — they need "
+            "the underlying performance issue fixed and the `SLOW` marker "
+            "removed from the workspace's `config/build/no_run.yaml`."
+        ),
+        entries=report.get("slow_skips") or [],
+    )
+    _render_tagged_section(
+        title="## Needs-Fix Scripts (parked for investigation)",
+        intro=(
+            "**{n} script(s)** are being skipped because they are broken and "
+            "parked as a to-do list. These are NOT permanent skips — investigate "
+            "the failure, fix the underlying bug, and remove the `NEEDS_FIX` "
+            "marker from the workspace's `config/build/no_run.yaml`."
+        ),
+        entries=report.get("needs_fix_skips") or [],
+    )
 
     # Summary
     s = report.get("summary", {})

--- a/autobuild/run_all.py
+++ b/autobuild/run_all.py
@@ -100,15 +100,23 @@ def main():
     print(f"Results directory: {results_dir}")
     print(f"Workspaces: {', '.join(workspaces)}")
 
-    from slow_skip_check import find_slow_skips, format_warning_banner, format_report_section
+    from slow_skip_check import (
+        find_slow_skips,
+        find_needs_fix_skips,
+        format_warning_banner,
+        format_report_section,
+    )
     ws_dirs_for_scan = [
         PYAUTOBASE / WORKSPACES[k][0]
         for k in workspaces
         if (PYAUTOBASE / WORKSPACES[k][0]).exists()
     ]
     slow_skips = find_slow_skips(ws_dirs_for_scan)
+    needs_fix_skips = find_needs_fix_skips(ws_dirs_for_scan)
     if slow_skips:
-        print(format_warning_banner(slow_skips))
+        print(format_warning_banner(slow_skips, category="slow"))
+    if needs_fix_skips:
+        print(format_warning_banner(needs_fix_skips, category="needs_fix"))
 
     for ws_key in workspaces:
         ws_name, project = WORKSPACES[ws_key]
@@ -137,6 +145,7 @@ def main():
 
     report = aggregate(results_dir)
     report["slow_skips"] = [s.to_dict() for s in slow_skips]
+    report["needs_fix_skips"] = [s.to_dict() for s in needs_fix_skips]
 
     import json
     with open(results_dir / "report.json", "w") as f:
@@ -168,7 +177,9 @@ def main():
         print(f"\nAll tests passed! Full report: {md_path}")
 
     if slow_skips:
-        print(format_warning_banner(slow_skips))
+        print(format_warning_banner(slow_skips, category="slow"))
+    if needs_fix_skips:
+        print(format_warning_banner(needs_fix_skips, category="needs_fix"))
 
     sys.exit(1 if failures else 0)
 

--- a/autobuild/slow_skip_check.py
+++ b/autobuild/slow_skip_check.py
@@ -1,14 +1,24 @@
 """
-Scan workspace no_run.yaml files for entries tagged as SLOW-skips and
-surface them so they cannot be silently forgotten.
+Scan workspace no_run.yaml files for entries tagged as SLOW-skips or
+NEEDS_FIX-skips and surface them so they cannot be silently forgotten.
 
 A SLOW-skip entry has an inline comment of the form:
 
     - scripts/foo/bar.py # SLOW 2026-04-10 - reason text
 
-The date is optional (entries with just `# SLOW - reason` are still picked
-up, but will report `date unknown`). Anything else in no_run.yaml is treated
-as a permanent skip and ignored by this scanner.
+A NEEDS_FIX entry has the same shape but with the `NEEDS_FIX` marker:
+
+    - scripts/foo/bar.py # NEEDS_FIX 2026-04-10 - reason text
+
+The date is optional in both cases (entries with just `# SLOW - reason` or
+`# NEEDS_FIX - reason` are still picked up, but will report `date unknown`).
+Anything else in no_run.yaml is treated as a permanent skip and ignored by
+this scanner.
+
+SLOW entries indicate scripts that exceed the 60s per-script timeout cap
+and need a performance fix. NEEDS_FIX entries indicate scripts that are
+broken and parked for later investigation — a to-do list surfaced on every
+mega-run so fixes don't get forgotten.
 """
 
 import dataclasses
@@ -20,16 +30,20 @@ from typing import List, Optional
 SLOW_RE = re.compile(
     r"^\s*SLOW(?:\s+(\d{4}-\d{2}-\d{2}))?\s*-\s*(.*)$"
 )
+NEEDS_FIX_RE = re.compile(
+    r"^\s*NEEDS_FIX(?:\s+(\d{4}-\d{2}-\d{2}))?\s*-\s*(.*)$"
+)
 
 STALE_THRESHOLD_DAYS = 30
 
 
 @dataclasses.dataclass
-class SlowSkip:
+class TaggedSkip:
     workspace: str
     pattern: str
     reason: str
     marked_date: Optional[datetime.date] = None
+    category: str = "slow"
 
     @property
     def age_days(self) -> Optional[int]:
@@ -50,7 +64,11 @@ class SlowSkip:
             "marked_date": self.marked_date.isoformat() if self.marked_date else None,
             "age_days": self.age_days,
             "is_stale": self.is_stale,
+            "category": self.category,
         }
+
+
+SlowSkip = TaggedSkip
 
 
 def _parse_entries(yaml_path: Path) -> List[tuple]:
@@ -73,15 +91,19 @@ def _parse_entries(yaml_path: Path) -> List[tuple]:
     return entries
 
 
-def find_slow_skips(workspace_dirs: List[Path]) -> List[SlowSkip]:
-    """Scan every workspace's config/build/no_run.yaml for SLOW-tagged entries."""
-    out: List[SlowSkip] = []
+def _scan_for_tag(
+    workspace_dirs: List[Path],
+    regex: re.Pattern,
+    category: str,
+) -> List[TaggedSkip]:
+    """Scan every workspace's config/build/no_run.yaml for entries matching regex."""
+    out: List[TaggedSkip] = []
     for ws_dir in workspace_dirs:
         no_run = ws_dir / "config" / "build" / "no_run.yaml"
         if not no_run.exists():
             continue
         for pattern, comment in _parse_entries(no_run):
-            m = SLOW_RE.match(comment)
+            m = regex.match(comment)
             if not m:
                 continue
             date_str, reason = m.group(1), m.group(2).strip()
@@ -91,31 +113,86 @@ def find_slow_skips(workspace_dirs: List[Path]) -> List[SlowSkip]:
                     marked_date = datetime.date.fromisoformat(date_str)
                 except ValueError:
                     marked_date = None
-            out.append(SlowSkip(
+            out.append(TaggedSkip(
                 workspace=ws_dir.name,
                 pattern=pattern,
                 reason=reason,
                 marked_date=marked_date,
+                category=category,
             ))
     return out
 
 
-def format_warning_banner(slow_skips: List[SlowSkip]) -> str:
-    """Return a loud, hard-to-miss plain-text banner listing every SLOW-skip."""
-    if not slow_skips:
+def find_slow_skips(workspace_dirs: List[Path]) -> List[TaggedSkip]:
+    """Scan every workspace's config/build/no_run.yaml for SLOW-tagged entries."""
+    return _scan_for_tag(workspace_dirs, SLOW_RE, category="slow")
+
+
+def find_needs_fix_skips(workspace_dirs: List[Path]) -> List[TaggedSkip]:
+    """Scan every workspace's config/build/no_run.yaml for NEEDS_FIX-tagged entries."""
+    return _scan_for_tag(workspace_dirs, NEEDS_FIX_RE, category="needs_fix")
+
+
+_BANNER_CONFIG = {
+    "slow": {
+        "header": "WARNING: {n} SLOW-SKIPPED SCRIPT(S) - needs performance fix",
+        "footer": [
+            "  These scripts are skipped because they exceed the 60s per-script",
+            "  cap. Fix the performance issue and remove the SLOW marker from",
+            "  the workspace's config/build/no_run.yaml.",
+        ],
+    },
+    "needs_fix": {
+        "header": "WARNING: {n} NEEDS-FIX SCRIPT(S) - broken, parked for investigation",
+        "footer": [
+            "  These scripts are broken and parked as a to-do list. Investigate",
+            "  the failure, fix the underlying bug, and remove the NEEDS_FIX",
+            "  marker from the workspace's config/build/no_run.yaml.",
+        ],
+    },
+}
+
+_REPORT_CONFIG = {
+    "slow": {
+        "title": "## Slow-Skipped Scripts (needs performance fix)",
+        "intro": (
+            "**{n} script(s)** are being skipped because they exceed the 60s "
+            "per-script timeout cap. These are NOT permanent skips — they need "
+            "the underlying performance issue fixed and the `SLOW` marker "
+            "removed from the workspace's `config/build/no_run.yaml`."
+        ),
+    },
+    "needs_fix": {
+        "title": "## Needs-Fix Scripts (parked for investigation)",
+        "intro": (
+            "**{n} script(s)** are being skipped because they are broken and "
+            "parked as a to-do list. These are NOT permanent skips — investigate "
+            "the failure, fix the underlying bug, and remove the `NEEDS_FIX` "
+            "marker from the workspace's `config/build/no_run.yaml`."
+        ),
+    },
+}
+
+
+def format_warning_banner(
+    skips: List[TaggedSkip], *, category: str = "slow"
+) -> str:
+    """Return a loud, hard-to-miss plain-text banner listing every tagged skip."""
+    if not skips:
         return ""
 
+    config = _BANNER_CONFIG[category]
     width = 72
     bar = "=" * width
     lines = [
         "",
         bar,
-        f"  WARNING: {len(slow_skips)} SLOW-SKIPPED SCRIPT(S) - needs performance fix",
+        f"  {config['header'].format(n=len(skips))}",
         bar,
     ]
 
     by_ws: dict = {}
-    for s in slow_skips:
+    for s in skips:
         by_ws.setdefault(s.workspace, []).append(s)
 
     for ws in sorted(by_ws):
@@ -132,30 +209,28 @@ def format_warning_banner(slow_skips: List[SlowSkip]) -> str:
         lines.append("")
 
     lines.append(bar)
-    lines.append("  These scripts are skipped because they exceed the 60s per-script")
-    lines.append("  cap. Fix the performance issue and remove the SLOW marker from")
-    lines.append("  the workspace's config/build/no_run.yaml.")
+    lines.extend(config["footer"])
     lines.append(bar)
     lines.append("")
     return "\n".join(lines)
 
 
-def format_report_section(slow_skips: List[SlowSkip]) -> str:
+def format_report_section(
+    skips: List[TaggedSkip], *, category: str = "slow"
+) -> str:
     """Return a markdown section for inclusion in the aggregated report.md."""
-    if not slow_skips:
+    if not skips:
         return ""
+    config = _REPORT_CONFIG[category]
     lines = [
-        "## Slow-Skipped Scripts (needs performance fix)",
+        config["title"],
         "",
-        f"**{len(slow_skips)} script(s)** are being skipped because they exceed the 60s "
-        "per-script timeout cap. These are NOT permanent skips — they need the "
-        "underlying performance issue fixed and the `SLOW` marker removed from the "
-        "workspace's `config/build/no_run.yaml`.",
+        config["intro"].format(n=len(skips)),
         "",
         "| Workspace | Script | Marked | Age | Reason |",
         "|-----------|--------|--------|-----|--------|",
     ]
-    for s in sorted(slow_skips, key=lambda x: (x.workspace, x.pattern)):
+    for s in sorted(skips, key=lambda x: (x.workspace, x.pattern)):
         date_str = s.marked_date.isoformat() if s.marked_date else "unknown"
         age_str = f"{s.age_days}d" if s.age_days is not None else "—"
         if s.is_stale:
@@ -178,5 +253,7 @@ if __name__ == "__main__":
         )
     ]
     targets = [Path(p) for p in sys.argv[1:]] or default_workspaces
-    skips = find_slow_skips(targets)
-    print(format_warning_banner(skips) or "No SLOW-skipped scripts found.")
+    slow = find_slow_skips(targets)
+    needs_fix = find_needs_fix_skips(targets)
+    print(format_warning_banner(slow, category="slow") or "No SLOW-skipped scripts found.")
+    print(format_warning_banner(needs_fix, category="needs_fix") or "No NEEDS_FIX-skipped scripts found.")


### PR DESCRIPTION
## Summary
Extends the existing SLOW-skip surfacing machinery with a parallel `NEEDS_FIX` category so that scripts parked pending investigation get a loud warning banner on every mega-run instead of being silently skipped. Mirror of the SLOW-skip workflow — parse inline comments, warn loudly, render in `report.md`.

## API Changes
None — internal changes only.

## Test Plan
- [x] `pytest tests/` — 21 passed
- [x] `python autobuild/slow_skip_check.py` — confirms 15 SLOW + 25 NEEDS_FIX entries are parsed across 5 workspaces
- [x] Spot-checked `build_util.should_skip` against precise vs. generic patterns (e.g. `autogalaxy_workspace/scripts/imaging/modeling` only matches the top-level `imaging/modeling.py`, not the 8 other `modeling.py` siblings)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `autobuild.slow_skip_check.NEEDS_FIX_RE` — regex matching `NEEDS_FIX <date> - <reason>` inline comments
- `autobuild.slow_skip_check.TaggedSkip` — generalized dataclass with `category` field
- `autobuild.slow_skip_check.find_needs_fix_skips(workspace_dirs)` — scanner wrapper
- `format_warning_banner(skips, *, category="slow")` and `format_report_section(skips, *, category="slow")` — category-aware formatters

### Changed Signature
- `format_warning_banner` / `format_report_section` — now take a keyword-only `category` argument (default `"slow"`, backwards compatible)

### Backwards-compat
- `SlowSkip` is kept as an alias for `TaggedSkip`

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)