### PR TITLE
Retire main_build: point PyAutoFit refs at main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
                 ref: main
                 path: PyAutoConf
               - repository: rhayes777/PyAutoFit
-                ref: main_build
+                ref: main
                 path: PyAutoFit
               - repository: Jammy2211/PyAutoArray
                 ref: main
@@ -493,7 +493,7 @@ jobs:
           path: PyAutoConf
           pat: PAT_RICH
         - repository: rhayes777/PyAutoFit
-          ref: main_build
+          ref: main
           path: PyAutoFit
           pat: PAT_RICH
         - repository: Jammy2211/PyAutoArray

--- a/autobuild/generate_release_notes.py
+++ b/autobuild/generate_release_notes.py
@@ -43,7 +43,7 @@ REPO_NAMES = {
 
 # Base branches per repo
 BASE_BRANCHES = {
-    "rhayes777/PyAutoFit": "main_build",
+    "rhayes777/PyAutoFit": "main",
     "Jammy2211/PyAutoArray": "main",
     "Jammy2211/PyAutoGalaxy": "main",
     "Jammy2211/PyAutoLens": "main",


### PR DESCRIPTION
## Summary
- PyAutoFit's \`main_build\` branch has been retired — \`origin/main\` now tracks the same tip.
- Update \`autobuild/generate_release_notes.py\` BASE_BRANCHES dict: \`rhayes777/PyAutoFit\` → \`main\`.
- Update \`.github/workflows/release.yml\`: two PyAutoFit checkout entries now use \`ref: main\`.

## Test plan
- [ ] Next manual dispatch of \`release.yml\` checks out PyAutoFit on \`main\` without error.
- [ ] \`generate_release_notes.py\` produces release notes against \`main\`.

Generated with [Claude Code](https://claude.com/claude-code)