### PR TITLE
fix: correct env var name and skip removed search packages

### DIFF
--- a/autobuild/config/env_vars.yaml
+++ b/autobuild/config/env_vars.yaml
@@ -9,7 +9,7 @@
 
 defaults:
   PYAUTOFIT_TEST_MODE: "2"
-  PYAUTO_WORKSPACE_SMALL_DATASETS: "1"
+  PYAUTO_SMALL_DATASETS: "1"
   PYAUTO_DISABLE_JAX: "1"
   PYAUTO_FAST_PLOTS: "1"
   JAX_ENABLE_X64: "True"
@@ -19,11 +19,11 @@ defaults:
 overrides:
   # start_here scripts load real FITS data that breaks with small datasets
   - pattern: "imaging/start_here"
-    unset: [PYAUTO_WORKSPACE_SMALL_DATASETS]
+    unset: [PYAUTO_SMALL_DATASETS]
   - pattern: "interferometer/start_here"
-    unset: [PYAUTO_WORKSPACE_SMALL_DATASETS]
+    unset: [PYAUTO_SMALL_DATASETS]
   - pattern: "group/start_here"
-    unset: [PYAUTO_WORKSPACE_SMALL_DATASETS]
+    unset: [PYAUTO_SMALL_DATASETS]
   # JAX likelihood functions need full-size datasets for accuracy testing
   - pattern: "jax_likelihood_functions/"
-    unset: [PYAUTO_WORKSPACE_SMALL_DATASETS]
+    unset: [PYAUTO_SMALL_DATASETS]

--- a/autobuild/config/no_run.yaml
+++ b/autobuild/config/no_run.yaml
@@ -3,6 +3,11 @@ autofit:
 - Zeus # Test Model Iniitalization no good.
 - ZeusPlotter # Test Model Iniitalization no good.
 - DynestyPlotter # Test Model Iniitalization no good.
+- UltraNest # UltraNest removed from autofit, ultranest package not installed.
+- UltraNestPlotter # UltraNest removed from autofit.
+- PySwarmsGlobal # PySwarms removed from autofit.
+- PySwarmsLocal # PySwarms removed from autofit.
+- PySwarmsPlotter # PySwarms removed from autofit.
 - start_point # bug https://github.com/rhayes777/PyAutoFit/issues/1017
 autogalaxy:
 - tutorial_searches


### PR DESCRIPTION
## Summary

Two build config fixes for the release pipeline:

1. **env_vars.yaml**: Rename `PYAUTO_WORKSPACE_SMALL_DATASETS` to `PYAUTO_SMALL_DATASETS` to match the variable name the library code actually checks. The mismatched name meant the override was silently ignored.

2. **no_run.yaml**: Add UltraNest, UltraNestPlotter, PySwarmsGlobal, PySwarmsLocal, PySwarmsPlotter to the skip list. These search algorithms were removed from PyAutoFit and the packages are no longer installed.

Relates to Jammy2211/PyAutoArray#269.

## API Changes
None — build configuration only.

## Test Plan
- [ ] Re-trigger release build after merging all PRs in this task

🤖 Generated with [Claude Code](https://claude.com/claude-code)