### PR TITLE
fix: auto-update dependency version pins during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,7 @@ jobs:
             pushd "${{ matrix.project.path }}"
             export VERSION="${{ needs.version_number.outputs.version_number }}"
             sed -i "s/__version__ = [\.\"\'0-9]*/__version__ = \"$VERSION\"/g" */__init__.py
+            sed -i "s/\(\"auto[a-z]*\)==[0-9][0-9\.]*\"/\1==$VERSION\"/g" pyproject.toml
             python3 -m pip install --upgrade build
             python3 -m build
             popd
@@ -555,6 +556,7 @@ jobs:
         pushd "${{ matrix.project.path }}"
         VERSION="${{ needs.version_number.outputs.version_number }}"
         sed -i "s/__version__ = [\.\"\'0-9]*/__version__ = \"$VERSION\"/g" */__init__.py
+        sed -i "s/\(\"auto[a-z]*\)==[0-9][0-9\.]*\"/\1==$VERSION\"/g" pyproject.toml
         git commit "-am 'Updated version in __init__ to $VERSION"
     - name: Tag
       if: "${{ github.event.inputs.skip_release != 'true' }}"


### PR DESCRIPTION
## Summary
- Add sed command to replace pinned PyAuto dependency versions in `pyproject.toml` with the release version
- Added in both the test-PyPI build step and the release step, matching the existing `__version__` sed pattern
- Pattern: `sed -i "s/\(\"auto[a-z]*\)==[0-9][0-9\.]*\"/\1==$VERSION\"/g" pyproject.toml`

## Test plan
- [ ] Dry-run sed against pyproject.toml files confirms correct matches
- [ ] Next release updates dependency pins to the new version number

🤖 Generated with [Claude Code](https://claude.com/claude-code)