### PR TITLE
Rename PYAUTOFIT_TEST_MODE → PYAUTO_TEST_MODE

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -779,9 +779,9 @@ jobs:
         run: |
           if [[ ${{ matrix.project.name }} == *_test ]]
           then
-            export PYAUTOFIT_TEST_MODE=0
+            export PYAUTO_TEST_MODE=0
           else
-            export PYAUTOFIT_TEST_MODE=1
+            export PYAUTO_TEST_MODE=1
             export PYAUTO_WORKSPACE_SMALL_DATASETS=1
             export PYAUTO_FAST_PLOTS=1
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ All scripts in `autobuild/` are run from within a checked-out workspace director
 ### Environment Variables
 
 - `BUILD_PYTHON_INTERPRETER` — Python interpreter to use for script execution (defaults to `python3`)
-- `PYAUTOFIT_TEST_MODE` — Set to `1` for workspace runs, `0` for `*_test` workspace runs
+- `PYAUTO_TEST_MODE` — Set to `1` for workspace runs, `0` for `*_test` workspace runs
 - `PYAUTO_WORKSPACE_SMALL_DATASETS` — Set to `1` for workspace runs (caps grids to 15x15), not set for `*_test` runs
 - `PYAUTO_FAST_PLOTS` — Set to `1` for workspace runs (skips `tight_layout()` in subplots and critical curve/caustic overlays in plots), not set for `*_test` runs
 - `JAX_ENABLE_X64` — Set to `True` during CI runs

--- a/autobuild/config/env_vars.yaml
+++ b/autobuild/config/env_vars.yaml
@@ -8,7 +8,7 @@
 #   - Patterns without '/' match the file stem exactly
 
 defaults:
-  PYAUTOFIT_TEST_MODE: "2"
+  PYAUTO_TEST_MODE: "2"
   PYAUTO_SMALL_DATASETS: "1"
   PYAUTO_DISABLE_JAX: "1"
   PYAUTO_FAST_PLOTS: "1"


### PR DESCRIPTION
## Summary
`autoconf/test_mode.py` reads only `PYAUTO_TEST_MODE`, so remaining `PYAUTOFIT_TEST_MODE` references were silent no-ops — CI and integration runs were not actually bypassing the sampler. Rename every occurrence to match the reader.

## API Changes
Environment variable renamed: `PYAUTOFIT_TEST_MODE` → `PYAUTO_TEST_MODE`. Library reader is unchanged (already only accepts the new name), so this only affects build/config/shell/script callsites that had been silently no-op'ing.
See full details below.

## Test Plan
- [x] `grep -rn PYAUTOFIT_TEST_MODE` across the affected repos — 0 matches after the rename
- [x] `autofit_workspace` smoke suite (7 scripts) re-run with the updated env_vars.yaml — all pass, Nautilus drops from ~60s to 4.3s now that the sampler-skip actually triggers

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Renamed
- Env var `PYAUTOFIT_TEST_MODE` → `PYAUTO_TEST_MODE` in every config/script/doc that still mentioned it.

### Migration
- If you have a local shell alias, `.claude/settings.local.json`, or CI step that sets `PYAUTOFIT_TEST_MODE=...`, rename it to `PYAUTO_TEST_MODE=...`. Old name is now a no-op (and always was — autoconf never read it after the earlier migration).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)