### PR TITLE
Skip EmceePlotter / NautilusPlotter under PYAUTO_TEST_MODE=2

### DIFF
--- a/autobuild/config/no_run.yaml
+++ b/autobuild/config/no_run.yaml
@@ -3,6 +3,8 @@ autofit:
 - Zeus # Test Model Iniitalization no good.
 - ZeusPlotter # Test Model Iniitalization no good.
 - DynestyPlotter # Test Model Iniitalization no good.
+- EmceePlotter # Needs result.search_internal, None under PYAUTO_TEST_MODE=2.
+- NautilusPlotter # Needs result.search_internal, None under PYAUTO_TEST_MODE=2.
 - UltraNest # UltraNest removed from autofit, ultranest package not installed.
 - UltraNestPlotter # UltraNest removed from autofit.
 - PySwarmsGlobal # PySwarms removed from autofit.


### PR DESCRIPTION
## Summary
Both plotter scripts access `result.search_internal`, which is `None` under `PYAUTO_TEST_MODE=2` (sampler bypass). Adding them to `no_run.yaml[autofit]` matches the existing policy for `DynestyPlotter`, `ZeusPlotter`, `UltraNestPlotter`, and `PySwarmsPlotter`.

## Test Plan
- [x] Full autofit_workspace smoke sweep: 40 pass / 0 fail / 12 skip (previously 30/13/10)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>