### PR TITLE
refactor(release): drop release branch, tag workspaces on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -680,16 +680,22 @@ jobs:
         python3 "$AUTOBUILD_PATH/generate.py" ${{ matrix.workspace.name }}
         git add *.ipynb
         git commit -m "Release ${{ needs.version_number.outputs.version_number }}: update notebooks and version" || true
-    - name: Release
+    - name: Write workspace version.txt
+      if: "${{ github.event.inputs.skip_release != 'true' }}"
+      run: |
+        VERSION="${{ needs.version_number.outputs.version_number }}"
+        pushd workspace
+        echo "$VERSION" > version.txt
+        git add version.txt
+        git commit -m "Release $VERSION: pin workspace version" || true
+    - name: Tag and push to main
       if: "${{ github.event.inputs.skip_release != 'true' }}"
       run: |
         cd workspace
-        git checkout release
-        git merge main
         VERSION="${{ needs.version_number.outputs.version_number }}"
         git tag -m "Release $VERSION" -a "$VERSION"
-        git push
-        git push --tags
+        git push origin main
+        git push origin --tags
 
 
   run_notebooks_and_release_workspaces:
@@ -794,24 +800,14 @@ jobs:
         run: |
           git config --global user.email "richard@rghsoftware.co.uk"
           git config --global user.name "GitHub Actions bot"
-      - name: Switch to release branch
-        if: "${{ github.event.inputs.update_notebook_visualisations == 'true' }}"
-        run: |
-          cd workspace
-          git checkout release
-      - name: Merge main into release
-        if: "${{ github.event.inputs.update_notebook_visualisations == 'true' }}"
-        run: |
-          cd workspace
-          git merge main
       - name: Commit visualizations
         if: "${{ github.event.inputs.update_notebook_visualisations == 'true' }}"
         run: |
           cd workspace
           git add .
           git commit -m "Updated notebooks with visualizations" || true
-      - name: Push to release branch
+      - name: Push to main
         if: "${{ github.event.inputs.update_notebook_visualisations == 'true' }}"
         run: |
           cd workspace
-          git push origin release
+          git push origin main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ PyAutoBuild is a CI/CD build server for the PyAuto software family (PyAutoConf, 
 1. Building and releasing packages to TestPyPI, then PyPI
 2. Running workspace Python scripts (integration tests)
 3. Converting Python scripts to Jupyter notebooks and executing them
-4. Updating workspace `release` branches with generated notebooks
+4. Committing generated notebooks to workspace `main` branches and tagging each workspace with a version matching the released library
 
 The pipeline is triggered via GitHub Actions (`release.yml`) and is manually dispatched with configurable options.
 
@@ -121,6 +121,6 @@ All scripts in `autobuild/` are run from within a checked-out workspace director
 The workflow (`release.yml`) is manually dispatched with inputs:
 - `minor_version` — appended to date-based version (format: `YYYY.M.D.minor`)
 - `skip_scripts` / `skip_notebooks` / `skip_release` — flags to skip pipeline stages
-- `update_notebook_visualisations` — runs notebooks with `--visualise` and pushes to `release` branch
+- `update_notebook_visualisations` — runs notebooks with `--visualise` and pushes the rendered output to `main`
 
 The `find_scripts` job uses `script_matrix.py` to dynamically generate the matrix for parallel `run_scripts` and `run_notebooks` jobs.

--- a/autobuild/tag_and_merge.py
+++ b/autobuild/tag_and_merge.py
@@ -6,12 +6,6 @@ WORKSPACE = "../"
 
 LIB_PROJECTS = ["PyAutoConf", "PyAutoFit", "PyAutoArray", "PyAutoLens", "PyAutoGalaxy"]
 
-WORKSPACE_PROJECTS = [
-    #'autolens_workspace', 'autofit_workspace', 'autolens_workspace_test'
-    "autolens_workspace",
-    "autofit_workspace",
-]
-
 
 def main(version):
     for project in LIB_PROJECTS:
@@ -22,28 +16,11 @@ def main(version):
             ["git", "commit", "-a", "-m", f"Update version to {version}"], check=True
         )
         subprocess.run(["git", "tag", f"v{version}"], check=True)
-        # subprocess.run(['git', 'push', 'origin', 'master', '--tags'], check=True)
         os.chdir(old_dir)
-
-    """
-    for project in WORKSPACE_PROJECTS:
-        print(f'Tagging {project}')
-        old_dir = os.getcwd()
-        os.chdir(os.path.join(WORKSPACE, project))
-        subprocess.run(['git', 'checkout', 'master'], check=True)
-        #subprocess.run(['git', 'commit', '-a', '-m', f'Update version to {version}'], check=True)
-        subprocess.run(['git', 'tag', f'v{version}'], check=True)
-        #subprocess.run(['git', 'push', 'origin', 'master', '--tags'], check=True)
-        subprocess.run(['git', 'fetch'], check=True)
-        subprocess.run(['git', 'checkout', 'release'], check=True)
-        subprocess.run(['git', 'merge', 'master'], check=True)
-        #subprocess.run(['git', 'push', 'origin', 'release', '--tags'], check=True)
-        os.chdir(old_dir)
-    """
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Tag and merge projects for release")
+    parser = argparse.ArgumentParser(description="Tag library projects for release")
     parser.add_argument("--version", type=str, required=True, help="Version to use")
 
     args = parser.parse_args()


### PR DESCRIPTION
## Summary

The `release_workspaces` job in `release.yml` previously did `git checkout release; git merge main; push release`. This made the `release` branch the source of truth for what users got from `pip install`, but it also caused the autolens_workspace #54/#55/#58/#59/#61 and autogalaxy_workspace #28 silent overwrites: when a contributor opened a PR via the GitHub UI the default base became `release`, and the next nightly merge rolled their work back.

This PR rips the `release` branch out of the build pipeline. Workspaces are now tagged on `main` with the same version as the libraries (e.g. `2026.4.13.6`). Companion to PyAutoLabs/autolens_workspace#71. The `--default-branch main` flip on the three workspace repos has already been applied via `gh repo edit`.

## API Changes

None — internal CI/build changes only.

The release pipeline output changes shape: workspaces gain a `version.txt` and a tag matching the library version, rather than a `release` branch update. Users who clone via `git clone --branch <version> <workspace-repo>` (the new install-doc flow) will now succeed.

See full details below.

## Test Plan

- [x] `pytest tests/` — 21 tests pass.
- [ ] Next `pre_build` + release dispatch: verify each workspace ends up with a new tag matching the library version, a `version.txt` containing that version on `main`, and no commits to `release`.
- [ ] After the next release, confirm `release` branch is no longer touched.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- `tag_and_merge.py`'s `WORKSPACE_PROJECTS` constant and the dead docstring block that referenced workspace `release` checkout. Library tagging logic is unchanged.

### Changed Behaviour
- `release.yml` — `release_workspaces` job: previously did `git checkout release; git merge main; tag; push (release + tags)`. Now writes `version.txt` to `main`, commits, tags at the matching library version, and pushes `main` + tags.
- `release.yml` — `run_notebooks_and_release_workspaces` job: previously synced visualisations to `release`. Now commits and pushes them to `main`.

### Migration
- The `release` branch on each workspace is now stale. It can be deleted in a follow-up step (deferred — destructive, separate confirmation).
- Anyone with a workspace checkout on `release` should `git checkout main` and `git pull`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)