### PR TITLE
Add Colab URL guard + release-pipeline tag bumper

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -688,6 +688,14 @@ jobs:
         echo "$VERSION" > version.txt
         git add version.txt
         git commit -m "Release $VERSION: pin workspace version" || true
+    - name: Bump Colab URL tag refs
+      if: "${{ github.event.inputs.skip_release != 'true' }}"
+      run: |
+        VERSION="${{ needs.version_number.outputs.version_number }}"
+        pushd workspace
+        bash "$GITHUB_WORKSPACE/PyAutoBuild/autobuild/bump_colab_urls.sh" "$VERSION"
+        git add -A
+        git commit -m "Release $VERSION: bump Colab URL tag refs" || true
     - name: Tag and push to main
       if: "${{ github.event.inputs.skip_release != 'true' }}"
       run: |
@@ -697,6 +705,43 @@ jobs:
         git push origin main
         git push origin --tags
 
+
+  bump_library_colab_urls:
+    runs-on: ubuntu-latest
+    env:
+      PAT: ${{ secrets.PAT_PYAUTOLABS }}
+    needs:
+      - release
+      - version_number
+    if: "${{ github.event.inputs.skip_release != 'true' }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        library:
+          - PyAutoLabs/PyAutoFit
+          - PyAutoLabs/PyAutoGalaxy
+          - PyAutoLabs/PyAutoLens
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: PyAutoBuild
+    - name: Checkout library
+      run: |
+        git clone -b main "https://$PAT@github.com/${{ matrix.library }}.git" library
+    - name: Configure Git
+      run: |
+        git config --global user.email "richard@rghsoftware.co.uk"
+        git config --global user.name "GitHub Actions bot"
+    - name: Bump Colab URL tag refs
+      run: |
+        VERSION="${{ needs.version_number.outputs.version_number }}"
+        pushd library
+        bash "$GITHUB_WORKSPACE/PyAutoBuild/autobuild/bump_colab_urls.sh" "$VERSION"
+        if ! git diff --quiet; then
+          git add -A
+          git commit -m "Release $VERSION: bump Colab URL tag refs"
+          git push origin main
+        fi
 
   run_notebooks_and_release_workspaces:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,8 @@ All scripts in `autobuild/` are run from within a checked-out workspace director
 - **`generate.py <project>`** — Converts Python scripts in `scripts/` to `.ipynb` notebooks in `notebooks/`, run from within the workspace root
 - **`script_matrix.py <project1> [project2 ...]`** — Outputs a JSON matrix of `{name, directory}` pairs for GitHub Actions matrix strategy
 - **`tag_and_merge.py --version <version>`** — Tags library repos for release
+- **`url_check.sh [directory]`** — Fails if any forbidden Binder/Colab URL pattern appears in `*.rst`, `*.md`, `*.ipynb`, or `*.py` under the directory. Forbidden: any `mybinder.org` URL, Colab URLs with `Jammy2211/` owner, and Colab URLs pinned to `/blob/release/`. Each affected workspace and library repo runs this in CI to prevent regressions.
+- **`bump_colab_urls.sh <new-tag>`** — Rewrites every `colab.research.google.com/github/PyAutoLabs/<workspace>/blob/<old-tag>/...` URL in cwd to use `<new-tag>`. Called by the `release_workspaces` and `bump_library_colab_urls` jobs in `release.yml` so README/docs Colab links always pin to the just-released workspace tag. Idempotent; skips URLs not in canonical PyAutoLabs/date-tagged form.
 
 ## Architecture
 

--- a/autobuild/bump_colab_urls.sh
+++ b/autobuild/bump_colab_urls.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# bump_colab_urls.sh - bump the tag ref in Colab URLs across the cwd.
+#
+# Usage: bump_colab_urls.sh <new-tag>
+#
+# Replaces every URL of the form
+#   colab.research.google.com/github/PyAutoLabs/<workspace>/blob/<old-tag>/...
+# with <new-tag>, in-place across *.rst, *.md, *.ipynb, *.py.
+#
+# <workspace> is one of autofit_workspace, autogalaxy_workspace, autolens_workspace.
+# <old-tag> must match the date-based scheme YYYY.M.D.B (anything else is left alone,
+# so the bumper is a no-op until the URL sweep migrates URLs to canonical form).
+# The script is idempotent: running it twice with the same tag is a no-op.
+
+set -eu
+
+NEW_TAG="${1:-}"
+if [ -z "$NEW_TAG" ]; then
+  echo "Usage: bump_colab_urls.sh <new-tag>" >&2
+  exit 2
+fi
+
+if ! [[ "$NEW_TAG" =~ ^[0-9]{4}\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "bump_colab_urls.sh: tag must look like YYYY.M.D.B; got: $NEW_TAG" >&2
+  exit 2
+fi
+
+PATTERN='(colab\.research\.google\.com/github/PyAutoLabs/(autofit|autogalaxy|autolens)_workspace/blob/)[0-9]{4}\.[0-9]+\.[0-9]+\.[0-9]+/'
+REPLACE="\${1}${NEW_TAG}/"
+
+find . -type f \( -name '*.rst' -o -name '*.md' -o -name '*.ipynb' -o -name '*.py' \) \
+  -exec perl -i -pe "s#${PATTERN}#${REPLACE}#g" {} +

--- a/autobuild/url_check.sh
+++ b/autobuild/url_check.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# url_check.sh - fail if forbidden Binder/Colab URL patterns appear in docs.
+#
+# Usage: url_check.sh [directory]
+# Exits 0 if clean, 1 if any forbidden patterns are found, 2 on usage error.
+#
+# Forbidden patterns:
+#   1. Any mybinder.org URL — Binder is no longer supported, use Colab.
+#   2. Colab URL with Jammy2211 owner — workspaces now live under PyAutoLabs.
+#   3. Colab URL pinned to /blob/release/ — the release branch is gone, pin to a tag.
+
+set -u
+
+DIR="${1:-.}"
+
+if [ ! -d "$DIR" ]; then
+  echo "url_check.sh: not a directory: $DIR" >&2
+  exit 2
+fi
+
+PATTERNS=(
+  'mybinder\.org'
+  'colab\.research\.google\.com/github/Jammy2211/'
+  'colab\.research\.google\.com/github/[^/]+/[^/]+/blob/release/'
+)
+
+LABELS=(
+  'mybinder.org URL (Binder is no longer supported — use Colab)'
+  'Colab URL with Jammy2211 owner (use PyAutoLabs)'
+  'Colab URL pinned to /blob/release/ (use a tagged version)'
+)
+
+found=0
+for i in "${!PATTERNS[@]}"; do
+  pattern="${PATTERNS[$i]}"
+  label="${LABELS[$i]}"
+  matches=$(grep -REn \
+    --include='*.rst' --include='*.md' --include='*.ipynb' --include='*.py' \
+    "$pattern" "$DIR" 2>/dev/null || true)
+  if [ -n "$matches" ]; then
+    found=1
+    echo ""
+    echo "FORBIDDEN: $label"
+    echo "$matches"
+  fi
+done
+
+if [ "$found" -eq 1 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/test_bump_colab_urls.py
+++ b/tests/test_bump_colab_urls.py
@@ -1,0 +1,131 @@
+import os
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "autobuild" / "bump_colab_urls.sh"
+
+
+def run(directory, tag):
+    return subprocess.run(
+        ["bash", str(SCRIPT), tag],
+        capture_output=True,
+        text=True,
+        cwd=directory,
+    )
+
+
+def test_bumps_workspace_tag(tmp_path):
+    f = tmp_path / "README.rst"
+    f.write_text(
+        "https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/start_here.ipynb"
+    )
+    result = run(tmp_path, "2026.5.0.0")
+    assert result.returncode == 0, result.stderr
+    assert (
+        f.read_text()
+        == "https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.5.0.0/start_here.ipynb"
+    )
+
+
+def test_bumps_all_three_workspaces(tmp_path):
+    contents = (
+        "autofit:    https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.1.0.0/a.ipynb\n"
+        "autogalaxy: https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.2.0.0/b.ipynb\n"
+        "autolens:   https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.3.0.0/c.ipynb\n"
+    )
+    f = tmp_path / "all.md"
+    f.write_text(contents)
+    result = run(tmp_path, "2026.5.0.0")
+    assert result.returncode == 0, result.stderr
+    out = f.read_text()
+    assert out.count("/blob/2026.5.0.0/") == 3
+    assert "2026.1.0.0" not in out
+    assert "2026.2.0.0" not in out
+    assert "2026.3.0.0" not in out
+
+
+def test_idempotent(tmp_path):
+    f = tmp_path / "README.rst"
+    original = (
+        "https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.5.0.0/start_here.ipynb"
+    )
+    f.write_text(original)
+    run(tmp_path, "2026.5.0.0")
+    run(tmp_path, "2026.5.0.0")
+    assert f.read_text() == original
+
+
+def test_leaves_jammy2211_alone(tmp_path):
+    """Owner cleanup is the URL sweep PR's job, not the bumper's."""
+    original = (
+        "https://colab.research.google.com/github/Jammy2211/autolens_workspace/blob/2026.1.0.0/start_here.ipynb"
+    )
+    f = tmp_path / "README.rst"
+    f.write_text(original)
+    result = run(tmp_path, "2026.5.0.0")
+    assert result.returncode == 0
+    assert f.read_text() == original
+
+
+def test_leaves_release_ref_alone(tmp_path):
+    """Branch refs are not date-tagged, so the bumper skips them — url_check.sh catches these instead."""
+    original = (
+        "https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/release/start_here.ipynb"
+    )
+    f = tmp_path / "README.rst"
+    f.write_text(original)
+    result = run(tmp_path, "2026.5.0.0")
+    assert result.returncode == 0
+    assert f.read_text() == original
+
+
+def test_leaves_non_workspace_urls_alone(tmp_path):
+    original = (
+        "https://colab.research.google.com/github/PyAutoLabs/PyAutoFit/blob/2026.1.0.0/some.ipynb"
+    )
+    f = tmp_path / "README.rst"
+    f.write_text(original)
+    result = run(tmp_path, "2026.5.0.0")
+    assert result.returncode == 0
+    assert f.read_text() == original
+
+
+def test_rejects_non_date_tag(tmp_path):
+    result = run(tmp_path, "v1.15.2")
+    assert result.returncode == 2
+    assert "YYYY.M.D.B" in result.stderr
+
+
+def test_rejects_missing_arg(tmp_path):
+    result = subprocess.run(
+        ["bash", str(SCRIPT)], capture_output=True, text=True, cwd=tmp_path
+    )
+    assert result.returncode == 2
+
+
+def test_handles_empty_directory(tmp_path):
+    result = run(tmp_path, "2026.5.0.0")
+    assert result.returncode == 0
+
+
+def test_recurses_into_subdirectories(tmp_path):
+    nested = tmp_path / "docs" / "howto"
+    nested.mkdir(parents=True)
+    f = nested / "intro.rst"
+    f.write_text(
+        "https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.1.0.0/a.ipynb"
+    )
+    result = run(tmp_path, "2026.5.0.0")
+    assert result.returncode == 0
+    assert "/blob/2026.5.0.0/" in f.read_text()
+
+
+def test_leaves_unscanned_extensions(tmp_path):
+    f = tmp_path / "data.txt"
+    original = (
+        "https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.1.0.0/x.ipynb"
+    )
+    f.write_text(original)
+    result = run(tmp_path, "2026.5.0.0")
+    assert result.returncode == 0
+    assert f.read_text() == original

--- a/tests/test_url_check.py
+++ b/tests/test_url_check.py
@@ -1,0 +1,79 @@
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "autobuild" / "url_check.sh"
+
+
+def run(directory):
+    return subprocess.run(
+        ["bash", str(SCRIPT), str(directory)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_clean_directory_passes(tmp_path):
+    (tmp_path / "README.rst").write_text(
+        "See `Try on Colab "
+        "<https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/start_here.ipynb>`_."
+    )
+    result = run(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_mybinder_url_fails(tmp_path):
+    (tmp_path / "README.rst").write_text(
+        "See `Binder <https://mybinder.org/v2/gh/PyAutoLabs/autofit_workspace/main?filepath=foo.ipynb>`_."
+    )
+    result = run(tmp_path)
+    assert result.returncode == 1
+    assert "mybinder.org" in result.stdout
+
+
+def test_jammy2211_colab_owner_fails(tmp_path):
+    (tmp_path / "docs.md").write_text(
+        "https://colab.research.google.com/github/Jammy2211/autolens_workspace/blob/2026.4.13.6/start_here.ipynb"
+    )
+    result = run(tmp_path)
+    assert result.returncode == 1
+    assert "Jammy2211" in result.stdout
+
+
+def test_release_branch_ref_fails(tmp_path):
+    (tmp_path / "intro.rst").write_text(
+        "https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/release/start_here.ipynb"
+    )
+    result = run(tmp_path)
+    assert result.returncode == 1
+    assert "/blob/release/" in result.stdout
+
+
+def test_unscanned_extensions_ignored(tmp_path):
+    (tmp_path / "data.txt").write_text("https://mybinder.org/v2/gh/foo/bar/main")
+    result = run(tmp_path)
+    assert result.returncode == 0
+
+
+def test_nested_directories_scanned(tmp_path):
+    nested = tmp_path / "docs" / "tutorials"
+    nested.mkdir(parents=True)
+    (nested / "intro.rst").write_text(
+        "https://colab.research.google.com/github/Jammy2211/autofit_workspace/blob/release/foo.ipynb"
+    )
+    result = run(tmp_path)
+    assert result.returncode == 1
+    assert "intro.rst" in result.stdout
+
+
+def test_missing_directory_errors(tmp_path):
+    result = run(tmp_path / "does-not-exist")
+    assert result.returncode == 2
+
+
+def test_ipynb_files_scanned(tmp_path):
+    (tmp_path / "demo.ipynb").write_text(
+        '{"cells": [{"source": ["[Binder](https://mybinder.org/v2/gh/foo/bar/main)"]}]}'
+    )
+    result = run(tmp_path)
+    assert result.returncode == 1
+    assert "demo.ipynb" in result.stdout


### PR DESCRIPTION
## Summary
First PR in the chain that retires the Binder "Try in browser" links and pins every Colab URL across the PyAuto ecosystem to the tagged workspace version that matches the latest released library. This PR ships the shared infrastructure; the cross-repo URL sweep follows in subsequent PRs against the 7 workspace + library + euclid repos.

Tracking issue: autolens_workspace#73 — built on top of the just-merged `default-branch-release-to-main` cleanup (autolens_workspace#71).

## API Changes
None — internal infrastructure additions only.

Two new shell helpers in `autobuild/` and one new job in `release.yml`. No existing public functions, classes, scripts, or workflow inputs change.

## Test Plan
- [x] `pytest tests/` — 40/40 pass (19 new, 21 pre-existing)
- [x] `python -c "import yaml; yaml.safe_load(open('PyAutoBuild/.github/workflows/release.yml'))"` — release.yml is valid YAML
- [ ] Smoke-verify the new `bump_library_colab_urls` job on a dry-run release dispatch (manual, after merge)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `autobuild/url_check.sh` — CI guard. Exits non-zero if any of three forbidden URL patterns appear under the cwd in `*.rst`, `*.md`, `*.ipynb`, `*.py`:
  1. any `mybinder.org` URL (Binder is no longer supported);
  2. Colab URLs with `Jammy2211/` owner (workspaces now live under `PyAutoLabs/`);
  3. Colab URLs pinned to `/blob/release/` (the dead branch ref).
  Each affected workspace and library repo will call this from its own CI in the follow-up PRs.
- `autobuild/bump_colab_urls.sh <new-tag>` — Rewrites every `colab.research.google.com/github/PyAutoLabs/<workspace>/blob/<old-tag>/...` URL in the cwd to use `<new-tag>`. Idempotent. Validates that `<new-tag>` matches the date-based scheme `YYYY.M.D.B`. Skips URLs not in canonical PyAutoLabs/date-tagged form so it never partially-rewrites mid-migration.
- New job `bump_library_colab_urls` in `release.yml` (matrix over `PyAutoFit`, `PyAutoGalaxy`, `PyAutoLens`): clones each library on `main`, runs the bumper, commits and pushes if any URLs changed. Depends on `release` and `version_number` so it only runs after a successful pypi upload.
- New step `Bump Colab URL tag refs` inside the existing `release_workspaces` job: same bumper applied to each workspace before `Tag and push to main`, so the tag created by the release captures the bumped URLs.
- `tests/test_url_check.py` (8 tests) and `tests/test_bump_colab_urls.py` (11 tests) cover the helpers via subprocess.

### Migration
None for users. For maintainers: once this lands, the next PRs in the chain (cross-repo URL sweep) can adopt `url_check.sh` in each repo's CI and use the canonical URL form that the bumper expects.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)