### PR TITLE
ci: integrate euclid_strong_lens_modeling_pipeline into release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -634,12 +634,23 @@ jobs:
           - repository: PyAutoLabs/autofit_workspace
             name: autofit
             package: PyAutoFit
+            generate_notebooks: true
+            bump_colab_urls: true
           - repository: PyAutoLabs/autogalaxy_workspace
             name: autogalaxy
             package: PyAutoGalaxy
+            generate_notebooks: true
+            bump_colab_urls: true
           - repository: PyAutoLabs/autolens_workspace
             name: autolens
             package: PyAutoLens
+            generate_notebooks: true
+            bump_colab_urls: true
+          - repository: Jammy2211/euclid_strong_lens_modeling_pipeline
+            name: euclid_pipeline
+            package: PyAutoLens
+            generate_notebooks: false
+            bump_colab_urls: false
     steps:
     - uses: actions/checkout@v2
       if: "${{ github.event.inputs.skip_release != 'true' }}"
@@ -672,7 +683,7 @@ jobs:
         sed -i "s/$PACKAGE v[0-9]\{4\}\.[0-9]*\.[0-9]*\.[0-9]*/$PACKAGE v$VERSION/g" README.rst README.md 2>/dev/null || true
         git add README.rst README.md 2>/dev/null || true
     - name: Update jupyter notebooks
-      if: "${{ github.event.inputs.skip_release != 'true' }}"
+      if: "${{ github.event.inputs.skip_release != 'true' && matrix.workspace.generate_notebooks == true }}"
       run: |
         export PYTHONPATH=$PYTHONPATH:$(pwd)/PyAutoBuild
         AUTOBUILD_PATH="$(pwd)/PyAutoBuild/autobuild"
@@ -689,7 +700,7 @@ jobs:
         git add version.txt
         git commit -m "Release $VERSION: pin workspace version" || true
     - name: Bump Colab URL tag refs
-      if: "${{ github.event.inputs.skip_release != 'true' }}"
+      if: "${{ github.event.inputs.skip_release != 'true' && matrix.workspace.bump_colab_urls == true }}"
       run: |
         VERSION="${{ needs.version_number.outputs.version_number }}"
         pushd workspace

--- a/pre_build.sh
+++ b/pre_build.sh
@@ -55,11 +55,12 @@ run_workspace() {
     fi
 }
 
-run_workspace "autofit_workspace"       "autofit"
-run_workspace "autogalaxy_workspace"    "autogalaxy"
-run_workspace "autolens_workspace"      "autolens"     true  true
-run_workspace "autofit_workspace_test"  "autofit"      false
-run_workspace "autolens_workspace_test" "autolens"     false
+run_workspace "autofit_workspace"                    "autofit"
+run_workspace "autogalaxy_workspace"                 "autogalaxy"
+run_workspace "autolens_workspace"                   "autolens"     true  true
+run_workspace "autofit_workspace_test"               "autofit"      false
+run_workspace "autolens_workspace_test"              "autolens"     false
+run_workspace "euclid_strong_lens_modeling_pipeline" ""             false
 
 # Commit and push PyAutoBuild itself
 echo ""


### PR DESCRIPTION
## Summary

Promote `Jammy2211/euclid_strong_lens_modeling_pipeline` to first-class workspace status in the release pipeline. Each release now tags it, writes its `version.txt`, and pushes the release commit, alongside the canonical 3 workspaces.

Tracking issue: https://github.com/Jammy2211/euclid_strong_lens_modeling_pipeline/issues/3

## Changes

- `release.yml` — add euclid as a 4th matrix entry in `release_workspaces`. Add `generate_notebooks` and `bump_colab_urls` per-matrix flags (true for canonical 3, false for euclid). Gate the corresponding steps on those flags.
- `pre_build.sh` — add `run_workspace "euclid_strong_lens_modeling_pipeline" "" false` so pre-build runs `black` on the repo and pushes any formatting changes.

## Why skip notebook generation and Colab URL bumping for euclid

- Euclid has no scripts/->notebooks/ mirror — generate.py would have nothing valid to convert.
- bump_colab_urls.sh only matches URLs of the form colab.research.google.com/github/PyAutoLabs/<workspace>/blob/<tag>/... — the euclid repo lives under the Jammy2211/ owner, so the bump would no-op anyway.

If we later restructure euclid to have a notebooks/ mirror, or move it under PyAutoLabs, flipping the matrix flags is a one-line change.

## Test Plan

- [ ] On the next release dispatch, confirm euclid appears as a 4th release_workspaces matrix job
- [ ] Confirm the "Update jupyter notebooks" and "Bump Colab URL tag refs" steps are skipped for the euclid job
- [ ] Confirm euclid receives a version.txt and a release tag
- [ ] Confirm the canonical 3 workspaces are unaffected

## API Changes

None — internal CI changes only.