### PR TITLE
Remove PySwarms and UltraNest references

### DIFF
--- a/autobuild/config/no_run.yaml
+++ b/autobuild/config/no_run.yaml
@@ -5,11 +5,6 @@ autofit:
 - DynestyPlotter # Test Model Iniitalization no good.
 - EmceePlotter # Needs result.search_internal, None under PYAUTO_TEST_MODE=2.
 - NautilusPlotter # Needs result.search_internal, None under PYAUTO_TEST_MODE=2.
-- UltraNest # UltraNest removed from autofit, ultranest package not installed.
-- UltraNestPlotter # UltraNest removed from autofit.
-- PySwarmsGlobal # PySwarms removed from autofit.
-- PySwarmsLocal # PySwarms removed from autofit.
-- PySwarmsPlotter # PySwarms removed from autofit.
 - start_point # bug https://github.com/PyAutoLabs/PyAutoFit/issues/1017
 autogalaxy:
 - tutorial_searches

--- a/test_results/autofit__plot__script.md
+++ b/test_results/autofit__plot__script.md
@@ -1,11 +1,11 @@
 # Test Report: autofit / plot (script)
 
-**7 scripts** | 2 passed | 5 skipped
+**5 scripts** | 2 passed | 3 skipped
 
 | Status | Count |
 |--------|-------|
 | passed | 2 |
-| skipped | 5 |
+| skipped | 3 |
 
 ## Skipped
 
@@ -13,8 +13,6 @@
 |--------|--------|
 | `DynestyPlotter.py` | Test Model Iniitalization no good. |
 | `GetDist.py` | Cant get it to install, even in optional requirements. |
-| `PySwarmsPlotter.py` | PySwarms does not support JAX. |
-| `UltraNestPlotter.py` | Test Model Iniitalization no good. |
 | `ZeusPlotter.py` | Test Model Iniitalization no good. |
 
 ## Passed

--- a/test_results/autofit__searches__script.md
+++ b/test_results/autofit__searches__script.md
@@ -1,20 +1,17 @@
 # Test Report: autofit / searches (script)
 
-**11 scripts** | 6 passed | 5 skipped
+**8 scripts** | 6 passed | 2 skipped
 
 | Status | Count |
 |--------|-------|
 | passed | 6 |
-| skipped | 5 |
+| skipped | 2 |
 
 ## Skipped
 
 | Script | Reason |
 |--------|--------|
 | `Zeus.py` | Test Model Iniitalization no good. |
-| `PySwarmsGlobal.py` | PySwarms does not support JAX. |
-| `PySwarmsLocal.py` | PySwarms does not support JAX. |
-| `UltraNest.py` | UltraNest does not support JAX. |
 | `start_point.py` | bug https://github.com/rhayes777/PyAutoFit/issues/1017 |
 
 ## Passed


### PR DESCRIPTION
## Summary
- Remove PySwarms and UltraNest references — these searches are no longer supported in PyAutoFit
- Strip scripts, notebooks, READMEs, config entries, tutorial prose, and citation lines that pointed users at broken examples
- The developer workspace is untouched (it intentionally preserves the legacy implementations)

## Test plan
- [ ] Grep sweep returns 0 hits for `pyswarm|ultranest` outside generated logs and `autofit_workspace_developer`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)