### PR TITLE
Update autofit skip-list for merged search scripts

### DIFF
--- a/autobuild/config/no_run.yaml
+++ b/autobuild/config/no_run.yaml
@@ -1,10 +1,10 @@
 autofit:
 - get_dist # Cant get it to install, even in optional requirements.
 - mcmc # Zeus section in merged mcmc.py fails Test Model Initialization.
-- ZeusPlotter # Test Model Iniitalization no good.
-- DynestyPlotter # Test Model Iniitalization no good.
-- EmceePlotter # Needs result.search_internal, None under PYAUTO_TEST_MODE=2.
-- NautilusPlotter # Needs result.search_internal, None under PYAUTO_TEST_MODE=2.
+- zeus_plotter # Test Model Iniitalization no good.
+- dynesty_plotter # Test Model Iniitalization no good.
+- emcee_plotter # Needs result.search_internal, None under PYAUTO_TEST_MODE=2.
+- nautilus_plotter # Needs result.search_internal, None under PYAUTO_TEST_MODE=2.
 - start_point # bug https://github.com/PyAutoLabs/PyAutoFit/issues/1017
 autogalaxy:
 - tutorial_searches

--- a/autobuild/config/no_run.yaml
+++ b/autobuild/config/no_run.yaml
@@ -1,6 +1,6 @@
 autofit:
-- GetDist # Cant get it to install, even in optional requirements.
-- Zeus # Test Model Iniitalization no good.
+- get_dist # Cant get it to install, even in optional requirements.
+- mcmc # Zeus section in merged mcmc.py fails Test Model Initialization.
 - ZeusPlotter # Test Model Iniitalization no good.
 - DynestyPlotter # Test Model Iniitalization no good.
 - EmceePlotter # Needs result.search_internal, None under PYAUTO_TEST_MODE=2.


### PR DESCRIPTION
## Summary
- Follow-up to PyAutoLabs/autofit_workspace#37, which renames `GetDist.py` → `get_dist.py` and merges `scripts/searches/mcmc/` into a single `mcmc.py`.
- Update basename stems in `autobuild/config/no_run.yaml` so the skip list continues to match: `GetDist` → `get_dist`, `Zeus` → `mcmc` (the merged `mcmc.py` still contains the broken Zeus section).

## Test plan
- [ ] CI on autofit_workspace PR #37 runs green under `PYAUTO_TEST_MODE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)