### PR TITLE
Register HowToLens and HowToGalaxy as build targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,13 +175,23 @@ jobs:
           with:
             repository: PyAutoLabs/autolens_workspace_test
             path: autolens_test
+        - name: Checkout HowToGalaxy
+          uses: actions/checkout@v2
+          with:
+            repository: PyAutoLabs/HowToGalaxy
+            path: howtogalaxy
+        - name: Checkout HowToLens
+          uses: actions/checkout@v2
+          with:
+            repository: PyAutoLabs/HowToLens
+            path: howtolens
         - uses: actions/checkout@v2
           with:
               path: PyAutoBuild
         - name: Make script matrix
           id: script_matrix
           run: |
-            matrix="$(./PyAutoBuild/autobuild/script_matrix.py autofit autogalaxy autolens autofit_test autolens_test)"
+            matrix="$(./PyAutoBuild/autobuild/script_matrix.py autofit autogalaxy autolens autofit_test autolens_test howtogalaxy howtolens)"
             echo "::set-output name=matrix::$matrix"
 
   generate_notebooks:
@@ -204,6 +214,12 @@ jobs:
           - name: autolens
             repository: PyAutoLabs/PyAutoLens
             workspace_repository: PyAutoLabs/autolens_workspace
+          - name: howtogalaxy
+            repository: PyAutoLabs/PyAutoGalaxy
+            workspace_repository: PyAutoLabs/HowToGalaxy
+          - name: howtolens
+            repository: PyAutoLabs/PyAutoLens
+            workspace_repository: PyAutoLabs/HowToLens
     steps:
     - name: Skip check
       if: "${{ github.event.inputs.skip_notebooks != 'true' }}"
@@ -288,6 +304,16 @@ jobs:
             echo "::set-output name=repository::PyAutoLabs/PyAutoFit"
             echo "::set-output name=workspace_repository::PyAutoLabs/autofit_workspace_test"
             echo "::set-output name=project::autofit"
+        elif [ ${{ matrix.project.name }} == "howtogalaxy" ]
+        then
+            echo "::set-output name=repository::PyAutoLabs/PyAutoGalaxy"
+            echo "::set-output name=workspace_repository::PyAutoLabs/HowToGalaxy"
+            echo "::set-output name=project::autogalaxy"
+        elif [ ${{ matrix.project.name }} == "howtolens" ]
+        then
+            echo "::set-output name=repository::PyAutoLabs/PyAutoLens"
+            echo "::set-output name=workspace_repository::PyAutoLabs/HowToLens"
+            echo "::set-output name=project::autolens"
         else
             echo "::set-output name=repository::PyAutoLabs/PyAutoLens"
             echo "::set-output name=workspace_repository::PyAutoLabs/autolens_workspace_test"
@@ -380,6 +406,16 @@ jobs:
         then
             echo "::set-output name=repository::PyAutoLabs/PyAutoLens"
             echo "::set-output name=workspace_repository::PyAutoLabs/autolens_workspace"
+            echo "::set-output name=project::autolens"
+        elif [ ${{ matrix.project.name }} == "howtogalaxy" ]
+        then
+            echo "::set-output name=repository::PyAutoLabs/PyAutoGalaxy"
+            echo "::set-output name=workspace_repository::PyAutoLabs/HowToGalaxy"
+            echo "::set-output name=project::autogalaxy"
+        elif [ ${{ matrix.project.name }} == "howtolens" ]
+        then
+            echo "::set-output name=repository::PyAutoLabs/PyAutoLens"
+            echo "::set-output name=workspace_repository::PyAutoLabs/HowToLens"
             echo "::set-output name=project::autolens"
         fi
 
@@ -643,6 +679,16 @@ jobs:
             bump_colab_urls: true
           - repository: PyAutoLabs/autolens_workspace
             name: autolens
+            package: PyAutoLens
+            generate_notebooks: true
+            bump_colab_urls: true
+          - repository: PyAutoLabs/HowToGalaxy
+            name: howtogalaxy
+            package: PyAutoGalaxy
+            generate_notebooks: true
+            bump_colab_urls: true
+          - repository: PyAutoLabs/HowToLens
+            name: howtolens
             package: PyAutoLens
             generate_notebooks: true
             bump_colab_urls: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,12 +30,14 @@ This script does the following for each repo:
 | `autolens_workspace` | yes | yes (`autolens`) | yes |
 | `autofit_workspace_test` | yes | no | yes |
 | `autolens_workspace_test` | yes | no | yes |
+| `HowToGalaxy` | yes | yes (`howtogalaxy`) | yes |
+| `HowToLens` | yes | yes (`howtolens`) | yes |
 
 `generate.py` is run from the workspace root with `PYTHONPATH` pointing at `PyAutoBuild/autobuild/`. Only specific safe directories are committed — never `output/`, `output_model/`, or run-generated artefacts. After all workspaces are done, PyAutoBuild itself is committed and pushed, then `gh workflow run release.yml` dispatches the GitHub Actions release.
 
 ## Workspace Folder Structure
 
-Each workspace repo (`autofit_workspace`, `autogalaxy_workspace`, `autolens_workspace`, and their `_test` variants) has the following expected structure. **Only these paths should ever be committed.**
+Each workspace repo (`autofit_workspace`, `autogalaxy_workspace`, `autolens_workspace`, their `_test` variants, and the lecture repos `HowToGalaxy`/`HowToLens`) has the following expected structure. **Only these paths should ever be committed.**
 
 | Folder / file | autofit | autogalaxy | autolens | Notes |
 |---|---|---|---|---|
@@ -84,7 +86,7 @@ All scripts in `autobuild/` are run from within a checked-out workspace director
 - **`script_matrix.py <project1> [project2 ...]`** — Outputs a JSON matrix of `{name, directory}` pairs for GitHub Actions matrix strategy
 - **`tag_and_merge.py --version <version>`** — Tags library repos for release
 - **`url_check.sh [directory]`** — Fails if any forbidden Binder/Colab URL pattern appears in `*.rst`, `*.md`, `*.ipynb`, or `*.py` under the directory. Forbidden: any `mybinder.org` URL, Colab URLs with `Jammy2211/` owner, and Colab URLs pinned to `/blob/release/`. Each affected workspace and library repo runs this in CI to prevent regressions.
-- **`bump_colab_urls.sh <new-tag>`** — Rewrites every `colab.research.google.com/github/PyAutoLabs/<workspace>/blob/<old-tag>/...` URL in cwd to use `<new-tag>`. Called by the `release_workspaces` and `bump_library_colab_urls` jobs in `release.yml` so README/docs Colab links always pin to the just-released workspace tag. Idempotent; skips URLs not in canonical PyAutoLabs/date-tagged form.
+- **`bump_colab_urls.sh <new-tag>`** — Rewrites every `colab.research.google.com/github/PyAutoLabs/<repo>/blob/<old-tag>/...` URL in cwd to use `<new-tag>`, where `<repo>` is one of `autofit_workspace`, `autogalaxy_workspace`, `autolens_workspace`, `HowToGalaxy`, `HowToLens`. Called by the `release_workspaces` and `bump_library_colab_urls` jobs in `release.yml` so README/docs Colab links always pin to the just-released tag. Idempotent; skips URLs not in canonical PyAutoLabs/date-tagged form.
 
 ## Architecture
 

--- a/autobuild/bump_colab_urls.sh
+++ b/autobuild/bump_colab_urls.sh
@@ -4,10 +4,12 @@
 # Usage: bump_colab_urls.sh <new-tag>
 #
 # Replaces every URL of the form
-#   colab.research.google.com/github/PyAutoLabs/<workspace>/blob/<old-tag>/...
+#   colab.research.google.com/github/PyAutoLabs/<repo>/blob/<old-tag>/...
 # with <new-tag>, in-place across *.rst, *.md, *.ipynb, *.py.
 #
-# <workspace> is one of autofit_workspace, autogalaxy_workspace, autolens_workspace.
+# <repo> is one of:
+#   autofit_workspace, autogalaxy_workspace, autolens_workspace
+#   HowToGalaxy, HowToLens
 # <old-tag> must match the date-based scheme YYYY.M.D.B (anything else is left alone,
 # so the bumper is a no-op until the URL sweep migrates URLs to canonical form).
 # The script is idempotent: running it twice with the same tag is a no-op.
@@ -25,7 +27,7 @@ if ! [[ "$NEW_TAG" =~ ^[0-9]{4}\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   exit 2
 fi
 
-PATTERN='(colab\.research\.google\.com/github/PyAutoLabs/(autofit|autogalaxy|autolens)_workspace/blob/)[0-9]{4}\.[0-9]+\.[0-9]+\.[0-9]+/'
+PATTERN='(colab\.research\.google\.com/github/PyAutoLabs/((autofit|autogalaxy|autolens)_workspace|HowToGalaxy|HowToLens)/blob/)[0-9]{4}\.[0-9]+\.[0-9]+\.[0-9]+/'
 REPLACE="\${1}${NEW_TAG}/"
 
 find . -type f \( -name '*.rst' -o -name '*.md' -o -name '*.ipynb' -o -name '*.py' \) \

--- a/autobuild/config/copy_files.yaml
+++ b/autobuild/config/copy_files.yaml
@@ -7,4 +7,6 @@ autolens:
 - imaging/advanced/chaining/hyper_mode/extensions.py
 autofit_test:
 autolens_test:
+howtogalaxy:
+howtolens:
 BSc_Galaxies_Project:

--- a/autobuild/config/no_run.yaml
+++ b/autobuild/config/no_run.yaml
@@ -48,3 +48,8 @@ autofit_test:
 - session/general # Session mostly works but not maintaining currently.
 - session/multi_analysis # Session mostly works but not maintaining currently.
 autolens_test: []
+howtogalaxy: []
+howtolens:
+- tutorial_searches
+- tutorial_5_borders # Cant get right masks, need proper update.
+- tutorial_6_model_fit # InversionException due to test mode

--- a/pre_build.sh
+++ b/pre_build.sh
@@ -61,6 +61,8 @@ run_workspace "autolens_workspace"                   "autolens"     true  true
 run_workspace "autofit_workspace_test"               "autofit"      false
 run_workspace "autolens_workspace_test"              "autolens"     false
 run_workspace "euclid_strong_lens_modeling_pipeline" ""             false
+run_workspace "HowToGalaxy"                          "howtogalaxy"
+run_workspace "HowToLens"                            "howtolens"
 
 # Commit and push PyAutoBuild itself
 echo ""


### PR DESCRIPTION
## Summary

Registers `HowToLens` and `HowToGalaxy` as first-class build targets in the release pipeline, parallel to the existing workspaces. Both repos already have the structural shape of a workspace (`scripts/chapter_N_*/`, `notebooks/chapter_N_*/`, `config/`, `version.txt`, `start_here.py`), so no restructuring was needed — just registration.

Previously neither repo was referenced anywhere in PyAutoBuild. The follow-up was noted after the HowToLens extraction (PyAutoLens PR #468) and again after the HowToGalaxy extraction (PyAutoGalaxy PR #363) but never acted on. This PR closes both follow-ups.

## What changes

| File | Change |
|---|---|
| `pre_build.sh` | Two new `run_workspace` calls for `HowToGalaxy` and `HowToLens` |
| `.github/workflows/release.yml` | `find_scripts`, `generate_notebooks` matrix, `run_scripts` Configure, `run_notebooks` Configure, `release_workspaces` matrix — all extended |
| `autobuild/config/copy_files.yaml` | New empty keys `howtogalaxy:` and `howtolens:` (required — `generate.py` crashes on missing key) |
| `autobuild/config/no_run.yaml` | `howtogalaxy: []` + `howtolens:` with three known-broken tutorials carried over from the pre-extraction autolens skiplist |
| `autobuild/bump_colab_urls.sh` | Regex extended so `PyAutoLabs/HowToGalaxy/blob/...` and `PyAutoLabs/HowToLens/blob/...` URLs get bumped alongside workspace URLs |
| `CLAUDE.md` | Workspace table + bump_colab_urls description updated |

## Why the bump_colab_urls.sh change matters

The HowToGalaxy and HowToLens extractions wrote Colab URLs like `PyAutoLabs/HowToLens/blob/TAG/notebooks/chapter_1/...` into PyAutoGalaxy/PyAutoLens docs, paper.md, and READMEs. The old regex only matched `(autofit|autogalaxy|autolens)_workspace`, so `bump_library_colab_urls` would silently skip every HowTo URL in the library docs on release. Smoke-tested the updated regex against a fixture with all three URL shapes — all bump correctly.

## First real exercise

Next `/pre_build` run. HowToLens/HowToGalaxy should get `version.txt` written, tagged, pushed, Colab URLs bumped, and their tutorials run in CI alongside the workspaces. If tutorial scripts break in CI for the first time the release report will flag them — acceptable first surface.

## Test plan

- [x] YAML lint: `release.yml`, `copy_files.yaml`, `no_run.yaml` all parse
- [x] Bash lint: `pre_build.sh` and `bump_colab_urls.sh` parse (`bash -n`)
- [x] `bump_colab_urls.sh` smoke-tested on a fixture with workspace + HowTo URLs — all bumped
- [ ] First `/pre_build` after merge — watch for any chapter-tutorial failures and populate `no_run.yaml` for `howtogalaxy`/`howtolens` as needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)