### PR TITLE
Register HowToFit as a build target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,13 +185,18 @@ jobs:
           with:
             repository: PyAutoLabs/HowToLens
             path: howtolens
+        - name: Checkout HowToFit
+          uses: actions/checkout@v2
+          with:
+            repository: PyAutoLabs/HowToFit
+            path: howtofit
         - uses: actions/checkout@v2
           with:
               path: PyAutoBuild
         - name: Make script matrix
           id: script_matrix
           run: |
-            matrix="$(./PyAutoBuild/autobuild/script_matrix.py autofit autogalaxy autolens autofit_test autolens_test howtogalaxy howtolens)"
+            matrix="$(./PyAutoBuild/autobuild/script_matrix.py autofit autogalaxy autolens autofit_test autolens_test howtogalaxy howtolens howtofit)"
             echo "::set-output name=matrix::$matrix"
 
   generate_notebooks:
@@ -220,6 +225,9 @@ jobs:
           - name: howtolens
             repository: PyAutoLabs/PyAutoLens
             workspace_repository: PyAutoLabs/HowToLens
+          - name: howtofit
+            repository: PyAutoLabs/PyAutoFit
+            workspace_repository: PyAutoLabs/HowToFit
     steps:
     - name: Skip check
       if: "${{ github.event.inputs.skip_notebooks != 'true' }}"
@@ -314,6 +322,11 @@ jobs:
             echo "::set-output name=repository::PyAutoLabs/PyAutoLens"
             echo "::set-output name=workspace_repository::PyAutoLabs/HowToLens"
             echo "::set-output name=project::autolens"
+        elif [ ${{ matrix.project.name }} == "howtofit" ]
+        then
+            echo "::set-output name=repository::PyAutoLabs/PyAutoFit"
+            echo "::set-output name=workspace_repository::PyAutoLabs/HowToFit"
+            echo "::set-output name=project::autofit"
         else
             echo "::set-output name=repository::PyAutoLabs/PyAutoLens"
             echo "::set-output name=workspace_repository::PyAutoLabs/autolens_workspace_test"
@@ -417,6 +430,11 @@ jobs:
             echo "::set-output name=repository::PyAutoLabs/PyAutoLens"
             echo "::set-output name=workspace_repository::PyAutoLabs/HowToLens"
             echo "::set-output name=project::autolens"
+        elif [ ${{ matrix.project.name }} == "howtofit" ]
+        then
+            echo "::set-output name=repository::PyAutoLabs/PyAutoFit"
+            echo "::set-output name=workspace_repository::PyAutoLabs/HowToFit"
+            echo "::set-output name=project::autofit"
         fi
 
     - uses: actions/checkout@v2
@@ -690,6 +708,11 @@ jobs:
           - repository: PyAutoLabs/HowToLens
             name: howtolens
             package: PyAutoLens
+            generate_notebooks: true
+            bump_colab_urls: true
+          - repository: PyAutoLabs/HowToFit
+            name: howtofit
+            package: PyAutoFit
             generate_notebooks: true
             bump_colab_urls: true
           - repository: Jammy2211/euclid_strong_lens_modeling_pipeline

--- a/autobuild/bump_colab_urls.sh
+++ b/autobuild/bump_colab_urls.sh
@@ -9,7 +9,7 @@
 #
 # <repo> is one of:
 #   autofit_workspace, autogalaxy_workspace, autolens_workspace
-#   HowToGalaxy, HowToLens
+#   HowToGalaxy, HowToLens, HowToFit
 # <old-tag> must match the date-based scheme YYYY.M.D.B (anything else is left alone,
 # so the bumper is a no-op until the URL sweep migrates URLs to canonical form).
 # The script is idempotent: running it twice with the same tag is a no-op.
@@ -27,7 +27,7 @@ if ! [[ "$NEW_TAG" =~ ^[0-9]{4}\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   exit 2
 fi
 
-PATTERN='(colab\.research\.google\.com/github/PyAutoLabs/((autofit|autogalaxy|autolens)_workspace|HowToGalaxy|HowToLens)/blob/)[0-9]{4}\.[0-9]+\.[0-9]+\.[0-9]+/'
+PATTERN='(colab\.research\.google\.com/github/PyAutoLabs/((autofit|autogalaxy|autolens)_workspace|HowToGalaxy|HowToLens|HowToFit)/blob/)[0-9]{4}\.[0-9]+\.[0-9]+\.[0-9]+/'
 REPLACE="\${1}${NEW_TAG}/"
 
 find . -type f \( -name '*.rst' -o -name '*.md' -o -name '*.ipynb' -o -name '*.py' \) \

--- a/autobuild/config/copy_files.yaml
+++ b/autobuild/config/copy_files.yaml
@@ -9,4 +9,5 @@ autofit_test:
 autolens_test:
 howtogalaxy:
 howtolens:
+howtofit:
 BSc_Galaxies_Project:

--- a/autobuild/config/no_run.yaml
+++ b/autobuild/config/no_run.yaml
@@ -53,3 +53,4 @@ howtolens:
 - tutorial_searches
 - tutorial_5_borders # Cant get right masks, need proper update.
 - tutorial_6_model_fit # InversionException due to test mode
+howtofit: []

--- a/pre_build.sh
+++ b/pre_build.sh
@@ -63,6 +63,7 @@ run_workspace "autolens_workspace_test"              "autolens"     false
 run_workspace "euclid_strong_lens_modeling_pipeline" ""             false
 run_workspace "HowToGalaxy"                          "howtogalaxy"
 run_workspace "HowToLens"                            "howtolens"
+run_workspace "HowToFit"                             "howtofit"
 
 # Commit and push PyAutoBuild itself
 echo ""


### PR DESCRIPTION
## Summary
Register `howtofit` as a first-class build target in PyAutoBuild so the release pipeline checks out, tests, Colab-bumps, and publishes the standalone HowToFit repository (https://github.com/PyAutoLabs/HowToFit) alongside HowToGalaxy and HowToLens. This mirrors the pattern established for those repos in #53 and completes the HowToFit extraction umbrella (PyAutoLabs/autofit_workspace#38, sub-4/4).

Closes #54.

Files touched:
- `pre_build.sh` — new `run_workspace "HowToFit" "howtofit"` entry
- `.github/workflows/release.yml` — HowToFit checkout, `script_matrix.py` arg, test-matrix entry, two resolver branches, and release-matrix entry (six edits mirroring the HowToLens blocks)
- `autobuild/bump_colab_urls.sh` — extend comment and regex alternation to include `HowToFit`
- `autobuild/config/copy_files.yaml` — add empty `howtofit:` entry
- `autobuild/config/no_run.yaml` — add `howtofit: []` entry

## API Changes
None — internal build-infrastructure changes only. No Python library API is affected; this extends the release-workflow matrix and config files so HowToFit participates in the same pipeline as the other workspaces.
See full details below.

## Test Plan
- [x] `python -m pytest tests/` — 38 passed (one pre-existing unrelated failure in `test_parse_no_run_reasons` deselected; broken on `main` after an earlier snake_case rename).
- [x] `python autobuild/script_matrix.py autofit autogalaxy autolens autofit_test autolens_test howtogalaxy howtolens howtofit` exits zero.
- [ ] First release workflow dispatch post-merge: confirm HowToFit is checked out, tested, Colab-URL-bumped, and published alongside the other targets.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- Build target `howtofit` is now recognised by the PyAutoBuild release pipeline:
  - `pre_build.sh` orchestrates it via `run_workspace "HowToFit" "howtofit"`.
  - `.github/workflows/release.yml` includes a HowToFit checkout, adds `howtofit` to the `script_matrix.py` argument list, adds it to the `generate_notebooks` matrix, adds resolver branches in both script-run and notebook-run configure steps (mapping `howtofit` → `PyAutoLabs/PyAutoFit` + `PyAutoLabs/HowToFit` + `project::autofit`), and adds it to the release-publish matrix with `package: PyAutoFit`.
  - `autobuild/bump_colab_urls.sh` regex alternation now includes `HowToFit`, so Colab notebook URLs for HowToFit are version-bumped in lockstep with the other workspaces.
  - `autobuild/config/copy_files.yaml` and `autobuild/config/no_run.yaml` both gain `howtofit` entries (empty/`[]`) so the per-workspace config machinery recognises the new target.

### Removed
None.

### Renamed
None.

### Changed Signature
None.

### Changed Behaviour
None — all edits are additive. Existing workspaces and how-to repos continue to build exactly as before.

### Migration
None — additive only.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)