### PR TITLE
Fix test_parse_no_run_reasons to expect snake_case key

### DIFF
--- a/tests/test_result_collector.py
+++ b/tests/test_result_collector.py
@@ -103,8 +103,8 @@ def test_parse_no_run_reasons():
         return  # Skip if config not available
 
     reasons = parse_no_run_reasons(config_path, "autofit")
-    assert "GetDist" in reasons
-    assert "install" in reasons["GetDist"].lower()
+    assert "get_dist" in reasons
+    assert "install" in reasons["get_dist"].lower()
 
     reasons_lens = parse_no_run_reasons(config_path, "autolens")
     assert "gui/mask" in reasons_lens


### PR DESCRIPTION
## Summary
`tests/test_result_collector.py::test_parse_no_run_reasons` has been broken on `main` since commit `e72a077` ("Rename per-sampler plotter stems to snake_case") renamed the `GetDist` entry in `autobuild/config/no_run.yaml` to `get_dist`. The test still asserted the old CamelCase key, so `pytest tests/` has been failing on every run. This PR updates the two assertions in the test to match the snake_case convention that the YAML now uses.

Surfaced during the HowToFit build-target PR (#55), where the failing test had to be `--deselect`ed to ship. This closes that loose end.

Closes #56.

## API Changes
None — test-only change. No production code, YAML, or workflow modified.
See full details below.

## Test Plan
- [x] `python -m pytest tests/` — 40/40 pass (no deselects needed).

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
None.

### Removed
None.

### Renamed
None.

### Changed Signature
None.

### Changed Behaviour
None — test-only change. The production code (`parse_no_run_reasons`) and the config (`no_run.yaml`) were already correct after the e72a077 rename; only the test assertion lagged behind.

### Migration
None.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)