### PR TITLE
fix: scope rglob to target directory in script/notebook finders

### DIFF
--- a/autobuild/build_util.py
+++ b/autobuild/build_util.py
@@ -171,7 +171,7 @@ def execute_notebooks_in_folder(
     # Infrastructure files — always skip, never report
     infra_skip = ["__init__", "README"]
     no_run_list.extend(infra_skip)
-    files = list(Path.cwd().rglob(f"{directory}/**/*.ipynb"))
+    files = list((Path.cwd() / directory).rglob("*.ipynb"))
 
     print(f"Found {len(files)} notebooks")
 
@@ -300,7 +300,7 @@ def find_scripts_in_folder(directory: str) -> List[Path]:
     -------
     A list of paths to the scripts
     """
-    files = list(Path.cwd().rglob(f"{directory}/**/*.py"))
+    files = list((Path.cwd() / directory).rglob("*.py"))
     return sorted(
         files,
         key=lambda f: (


### PR DESCRIPTION
## Summary
- `Path.cwd().rglob("scripts/**/*.py")` matches **any** directory named `scripts` anywhere in the tree (rglob scans every path, not just immediate children). That caused `autofit_workspace_test`'s mega-run to pick up `.github/scripts/run_smoke.py` as if it were a workspace script — and then time out because running it reinvokes the smoke suite.
- Scope the glob to the actual target directory: `(Path.cwd() / directory).rglob("*.py")`. Same fix for both `find_scripts_in_folder` and `execute_notebooks_in_folder`.

## Test plan
- [x] `pytest tests/` → 40 passed (including `test_script_order` which exercises `find_scripts_in_folder`)
- [x] Mega-run on `autofit_workspace_test` now reports 34 scripts (was 35); no spurious `.github/scripts/run_smoke.py` timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)