### PR TITLE
fix: enable fits_make / png_make smoke tests

### DIFF
--- a/autobuild/config/no_run.yaml
+++ b/autobuild/config/no_run.yaml
@@ -12,8 +12,6 @@ autogalaxy:
 - gui/mask_extra_galaxies # GUI scripts cannot be run
 - gui/mask # GUI scripts cannot be run
 - gui/extra_galaxies_centres # GUI scripts cannot be run
-- fits_make # Test mode does not output .fits images.
-- png_make # Test mode does not output .png images.
 - examples/searches # Test mode breaks search visualization.
 - data_fitting # Test mode breaks .fits file output
 - ellipse/database # Ellipse model needs refactor and JAX support
@@ -28,8 +26,6 @@ autolens:
 - gui/positions # GUI scripts cannot be run
 - deflections # Output HDU not supported for VectorYX Detections.
 - deflections_source_snr # Output HDU not supported for VectorYX Detections.
-- fits_make # Test mode does not output .fits images.
-- png_make # Test mode does not output .png images.
 - time_delays # Test mode does not support cosmology ift
 - hpc/example_cpu # HPC paths dont exist locally.
 - examples/searches # Test mode breaks search visualization.


### PR DESCRIPTION
## Summary

Remove `fits_make` / `png_make` from the `autogalaxy:` and `autolens:` skip lists in `autobuild/config/no_run.yaml`. The smoke runner can now execute these workflow examples — the matching workspace PRs make sure they actually produce output.

## Files Changed

- `autobuild/config/no_run.yaml` — drop 4 lines (`fits_make` / `png_make` under `autogalaxy:` and `autolens:` sections)

## Companion Workspace PRs

These need to merge alongside this PR for the smoke runner to actually exercise the scripts:

- autogalaxy_workspace — adds `env_vars.yaml` overrides + `n_like_max=300` in workflow scripts (URL added once opened)
- autolens_workspace — same (URL added once opened)

## Background

Workspace smoke tests run with `PYAUTO_SKIP_VISUALIZATION=1` and `PYAUTO_FAST_PLOTS=1`. The latter short-circuits `subplot_save` / `save_figure` in `autoarray/plot/utils.py` and closes every figure without writing it. That meant `fits_make` / `png_make` had nothing for the aggregator to extract, so they were skipped here. The workspace PRs override both env vars for the `fits_make` / `png_make` patterns and cap Nautilus at `n_like_max=300` so they finish in seconds.

Closes #59 (once the workspace PRs land too).

## Test Plan

- [ ] Smoke runner picks up the change and executes `fits_make.py` / `png_make.py` end-to-end in both workspaces, producing the expected `.fits` / `.png` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)