### PR TITLE
fix: rename stale PYAUTO_WORKSPACE_SMALL_DATASETS in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -913,7 +913,7 @@ jobs:
             export PYAUTO_TEST_MODE=0
           else
             export PYAUTO_TEST_MODE=1
-            export PYAUTO_WORKSPACE_SMALL_DATASETS=1
+            export PYAUTO_SMALL_DATASETS=1
             export PYAUTO_FAST_PLOTS=1
           fi
           export PYTHONPATH=$PYTHONPATH:$(pwd)/PyAutoBuild

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ Each workspace owns its own build config under `<workspace>/config/build/`:
 
 - `BUILD_PYTHON_INTERPRETER` — Python interpreter to use for script execution (defaults to `python3`)
 - `PYAUTO_TEST_MODE` — Set to `1` for workspace runs, `0` for `*_test` workspace runs
-- `PYAUTO_WORKSPACE_SMALL_DATASETS` — Set to `1` for workspace runs (caps grids to 15x15), not set for `*_test` runs
+- `PYAUTO_SMALL_DATASETS` — Set to `1` for workspace runs (caps grids to 15x15), not set for `*_test` runs
 - `PYAUTO_FAST_PLOTS` — Set to `1` for workspace runs (skips `tight_layout()` in subplots and critical curve/caustic overlays in plots), not set for `*_test` runs
 - `JAX_ENABLE_X64` — Set to `True` during CI runs
 


### PR DESCRIPTION
## Summary
The release workflow exports `PYAUTO_WORKSPACE_SMALL_DATASETS=1` for non-`*_test` workspace runs, but every consumer in the libraries checks `PYAUTO_SMALL_DATASETS`. The old name was a silent no-op, so workspace builds were running at full dataset size even though the build config claimed otherwise. Rename to the canonical name so the cap fires.

## Scripts Changed
- `.github/workflows/release.yml` — `export PYAUTO_WORKSPACE_SMALL_DATASETS=1` → `export PYAUTO_SMALL_DATASETS=1`
- `CLAUDE.md` — doc reference updated

Refs PyAutoLabs/autolens_workspace_test#65

## Test Plan
- [ ] Verify `release.yml` still parses and the env var lands in the workspace run step
- [ ] PyAutoBuild unit tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)