### PR TITLE
feat: HowTo* repos as first-class members of release window

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,11 @@ jobs:
           with:
             repository: PyAutoLabs/autofit_workspace_test
             path: autofit_test
+        - name: Checkout AutoGalaxy Test
+          uses: actions/checkout@v2
+          with:
+            repository: PyAutoLabs/autogalaxy_workspace_test
+            path: autogalaxy_test
         - name: Checkout AutoLens Test
           uses: actions/checkout@v2
           with:
@@ -196,7 +201,7 @@ jobs:
         - name: Make script matrix
           id: script_matrix
           run: |
-            matrix="$(./PyAutoBuild/autobuild/script_matrix.py autofit autogalaxy autolens autofit_test autolens_test howtogalaxy howtolens howtofit)"
+            matrix="$(./PyAutoBuild/autobuild/script_matrix.py autofit autogalaxy autolens autofit_test autogalaxy_test autolens_test howtogalaxy howtolens howtofit)"
             echo "::set-output name=matrix::$matrix"
 
   generate_notebooks:
@@ -312,6 +317,11 @@ jobs:
             echo "::set-output name=repository::PyAutoLabs/PyAutoFit"
             echo "::set-output name=workspace_repository::PyAutoLabs/autofit_workspace_test"
             echo "::set-output name=project::autofit"
+        elif [ ${{ matrix.project.name }} == "autogalaxy_test" ]
+        then
+            echo "::set-output name=repository::PyAutoLabs/PyAutoGalaxy"
+            echo "::set-output name=workspace_repository::PyAutoLabs/autogalaxy_workspace_test"
+            echo "::set-output name=project::autogalaxy"
         elif [ ${{ matrix.project.name }} == "howtogalaxy" ]
         then
             echo "::set-output name=repository::PyAutoLabs/PyAutoGalaxy"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,9 +29,16 @@ This script does the following for each repo:
 | `autogalaxy_workspace` | yes | yes (`autogalaxy`) | yes |
 | `autolens_workspace` | yes | yes (`autolens`) | yes |
 | `autofit_workspace_test` | yes | no | yes |
+| `autogalaxy_workspace_test` | yes | no | yes |
 | `autolens_workspace_test` | yes | no | yes |
+| `euclid_strong_lens_modeling_pipeline` | yes | no | yes |
 | `HowToGalaxy` | yes | yes (`howtogalaxy`) | yes |
 | `HowToLens` | yes | yes (`howtolens`) | yes |
+| `HowToFit` | yes | yes (`howtofit`) | yes |
+
+Before the per-repo loop, `pre_build.sh` invokes `admin_jammy/software/ensure_workspace_labels.sh` to assert the canonical `pending-release` label across every release-window repo (idempotent — a no-op when nothing has drifted).
+
+After the loop, before dispatching the workflow, `pre_build.sh` invokes `verify_workspace_versions.sh` — a fail-fast check that blocks the release if any workspace's `version.txt` is ahead of the currently-installed library version. This guards against bootstrap commits that set an aspirational `version.txt`, which would otherwise crash every `welcome.py` / `start_here.py` run with `WorkspaceVersionMismatchError` until the next release lands.
 
 `generate.py` is run from the workspace root with `PYTHONPATH` pointing at `PyAutoBuild/autobuild/`. Only specific safe directories are committed — never `output/`, `output_model/`, or run-generated artefacts. After all workspaces are done, PyAutoBuild itself is committed and pushed, then `gh workflow run release.yml` dispatches the GitHub Actions release.
 

--- a/pre_build.sh
+++ b/pre_build.sh
@@ -15,6 +15,14 @@ PYAUTOBASE="/mnt/c/Users/Jammy/Code/PyAutoLabs"
 AUTOBUILD="$PYAUTOBASE/PyAutoBuild/autobuild"
 PYTHONPATH_EXTRA="$AUTOBUILD"
 
+# Ensure the canonical `pending-release` label exists with the right config
+# across every release-window repo. Idempotent — no-ops when nothing drifted.
+if command -v gh >/dev/null 2>&1; then
+    echo ""
+    echo "=== Ensuring pending-release labels ==="
+    bash "$PYAUTOBASE/admin_jammy/software/ensure_workspace_labels.sh"
+fi
+
 run_workspace() {
     local repo="$1"
     local project="$2"
@@ -59,6 +67,7 @@ run_workspace "autofit_workspace"                    "autofit"
 run_workspace "autogalaxy_workspace"                 "autogalaxy"
 run_workspace "autolens_workspace"                   "autolens"     true  true
 run_workspace "autofit_workspace_test"               "autofit"      false
+run_workspace "autogalaxy_workspace_test"            "autogalaxy"   false
 run_workspace "autolens_workspace_test"              "autolens"     false
 run_workspace "euclid_strong_lens_modeling_pipeline" ""             false
 run_workspace "HowToGalaxy"                          "howtogalaxy"
@@ -76,6 +85,13 @@ else
     git commit -m "pre build"
     git push
 fi
+
+# Block release if any workspace's version.txt is ahead of its installed
+# library — every welcome.py / start_here.py run would otherwise crash with
+# WorkspaceVersionMismatchError until the release dispatch landed.
+echo ""
+echo "=== Verifying workspace versions ==="
+bash "$PYAUTOBASE/PyAutoBuild/verify_workspace_versions.sh"
 
 # Trigger the GitHub Actions release workflow
 echo ""

--- a/verify_workspace_versions.sh
+++ b/verify_workspace_versions.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# verify_workspace_versions.sh — fail fast if any workspace's version.txt is
+# AHEAD of the currently-installed library version.
+#
+# Usage: bash PyAutoBuild/verify_workspace_versions.sh
+#
+# Background: the bootstrap commit for a new workspace-style repo (HowToLens,
+# 2026-04-21) set version.txt to today's date as an aspirational tag. Until
+# the next release dispatch wrote a real version.txt, every welcome.py run
+# crashed with WorkspaceVersionMismatchError. This check blocks pre_build.sh
+# from dispatching a release that would be invalidated by such a mismatch.
+#
+# Compares each of the 7 workspaces with a version.txt (3 main + 3 HowTo +
+# euclid_pipeline) against its installed library version, parsed as a
+# YYYY.M.D.B 4-tuple of ints. Exits 1 if any workspace.version > library.version.
+#
+# Workspace → library mapping mirrors the release_workspaces matrix in
+# .github/workflows/release.yml.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYAUTOBASE="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# workspace_dir|python_package
+WORKSPACES=(
+    "autofit_workspace|autofit"
+    "autogalaxy_workspace|autogalaxy"
+    "autolens_workspace|autolens"
+    "HowToFit|autofit"
+    "HowToGalaxy|autogalaxy"
+    "HowToLens|autolens"
+    "euclid_strong_lens_modeling_pipeline|autolens"
+)
+
+# Compare two YYYY.M.D.B versions. Echoes AHEAD / BEHIND / MATCH / BAD.
+compare_versions() {
+    local v1="$1" v2="$2"
+    local IFS=.
+    # shellcheck disable=SC2206
+    local a=($v1) b=($v2)
+    if [ "${#a[@]}" -ne 4 ] || [ "${#b[@]}" -ne 4 ]; then
+        echo "BAD"
+        return
+    fi
+    local i
+    for i in 0 1 2 3; do
+        if ! [[ "${a[$i]}" =~ ^[0-9]+$ && "${b[$i]}" =~ ^[0-9]+$ ]]; then
+            echo "BAD"
+            return
+        fi
+        if [ "${a[$i]}" -gt "${b[$i]}" ]; then echo "AHEAD";  return; fi
+        if [ "${a[$i]}" -lt "${b[$i]}" ]; then echo "BEHIND"; return; fi
+    done
+    echo "MATCH"
+}
+
+failed=0
+
+for entry in "${WORKSPACES[@]}"; do
+    ws="${entry%%|*}"
+    pkg="${entry#*|}"
+    version_file="$PYAUTOBASE/$ws/version.txt"
+
+    if [ ! -f "$version_file" ]; then
+        printf "  %-45s SKIP (no version.txt)\n" "$ws"
+        continue
+    fi
+
+    ws_version=$(tr -d '[:space:]' < "$version_file")
+    if [ -z "$ws_version" ]; then
+        printf "  %-45s FAIL (version.txt is empty)\n" "$ws" >&2
+        failed=1
+        continue
+    fi
+
+    if ! lib_version=$(python3 -c "import $pkg; print($pkg.__version__)" 2>/dev/null); then
+        printf "  %-45s SKIP (cannot import %s)\n" "$ws" "$pkg"
+        continue
+    fi
+
+    case "$(compare_versions "$ws_version" "$lib_version")" in
+        MATCH)
+            printf "  %-45s ok       (%s)\n" "$ws" "$ws_version"
+            ;;
+        BEHIND)
+            printf "  %-45s ok       (workspace %s < installed %s — release will overwrite)\n" \
+                "$ws" "$ws_version" "$lib_version"
+            ;;
+        AHEAD)
+            printf "  %-45s FAIL     (workspace %s > installed %s — aspirational version!)\n" \
+                "$ws" "$ws_version" "$lib_version" >&2
+            failed=1
+            ;;
+        *)
+            printf "  %-45s FAIL     (could not parse versions: ws=%s lib=%s)\n" \
+                "$ws" "$ws_version" "$lib_version" >&2
+            failed=1
+            ;;
+    esac
+done
+
+if [ "$failed" -ne 0 ]; then
+    echo >&2
+    echo "verify_workspace_versions: at least one workspace is AHEAD of its installed library." >&2
+    echo "                           Release dispatch blocked. Patch the offending version.txt(s)" >&2
+    echo "                           to match the installed library, then re-run." >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Closes the HowTo* / euclid / autogalaxy_workspace_test gaps in the release-window admin around `pre_build.sh` and `release.yml`. Adds a fail-fast workspace-version check, wires `autogalaxy_workspace_test` into the release pipeline (it was orphaned), and brings `CLAUDE.md` back in sync with the actual `pre_build.sh` script.

Pairs with [Jammy2211/admin_jammy#13](https://github.com/Jammy2211/admin_jammy) which adds `ensure_workspace_labels.sh` — `pre_build.sh` invokes it on entry. Either repo can merge first; runtime sources both from `$PYAUTOBASE`.

Resolves #64.

## Changes

- **`pre_build.sh`** — invokes `admin_jammy/software/ensure_workspace_labels.sh` on entry (idempotent label sweep), invokes `verify_workspace_versions.sh` before the `gh workflow run` dispatch, and runs `autogalaxy_workspace_test` (which was missing entirely).
- **`verify_workspace_versions.sh`** (new) — for each of the 7 workspaces with `version.txt` (3 main + 3 HowTo + euclid), compares `version.txt` against the currently-installed library version. Exits 1 if any workspace is *ahead*. Wired into `pre_build.sh` to block dispatch when triggered.
- **`.github/workflows/release.yml`** — wires `autogalaxy_workspace_test` into the release pipeline:
  - `find_scripts`: new `Checkout AutoGalaxy Test` block
  - `script_matrix.py` arg list: adds `autogalaxy_test`
  - `run_scripts` configure block: new `elif autogalaxy_test` case
  Left alone: `run_notebooks` configure (no `_test` workspaces handled there today; out of scope).
- **`CLAUDE.md`** — table additions (`HowToFit`, `autogalaxy_workspace_test`, `euclid_strong_lens_modeling_pipeline`) and documentation for the two new `pre_build.sh` self-healing helpers.

## Test Plan

- [x] `bash verify_workspace_versions.sh` — exits 0 with all workspaces aligned at `2026.4.13.6`. Forced failure (HowToLens version.txt → `9999.1.1.0`) correctly exits 1 with a clear AHEAD message.
- [x] `bash admin_jammy/software/ensure_workspace_labels.sh` — exits 0; second run is a complete no-op (all 15 repos canonical).
- [x] `pytest tests/` — all PyAutoBuild internal tests pass on the worktree.
- [x] `python3 -c "import yaml; yaml.safe_load(open('release.yml'))"` — workflow YAML parses cleanly after the autogalaxy_test additions.
- [ ] Post-merge: dispatch `release.yml` with `--field skip_release=true --field skip_scripts=true --field skip_notebooks=true` to confirm matrix entries for `autogalaxy_test` and `howto*` are present.

## Out of scope (separate prompts)

- `release.yml`'s `autofit` configure branch sets `repository::PyAutoLabs/PyAutoGalaxy` (copy-paste bug) — independent of this task.
- `run_notebooks` configure block has no cases for any `_test` workspace — adding `autogalaxy_test` here would create new behaviour rather than parity with the existing `_test` workspaces, so left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)