### PR TITLE
fix(release.yml): autofit configure typo + skip _test in run_notebooks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,7 +235,7 @@ jobs:
             workspace_repository: PyAutoLabs/HowToFit
     steps:
     - name: Skip check
-      if: "${{ github.event.inputs.skip_notebooks != 'true' }}"
+      if: "${{ github.event.inputs.skip_notebooks != 'true' && !endsWith(matrix.project.name, '_test') }}"
       id: should_run
       run: echo "run=true" >> $GITHUB_OUTPUT
     - uses: actions/checkout@v2
@@ -412,12 +412,12 @@ jobs:
             ${{ fromJSON(needs.find_scripts.outputs.matrix) }}
     steps:
     - name: Configure
-      if: "${{ github.event.inputs.skip_notebooks != 'true' }}"
+      if: "${{ github.event.inputs.skip_notebooks != 'true' && !endsWith(matrix.project.name, '_test') }}"
       id: configure
       run: |
         if [ ${{ matrix.project.name }} == "autofit" ]
         then
-            echo "::set-output name=repository::PyAutoLabs/PyAutoGalaxy"
+            echo "::set-output name=repository::PyAutoLabs/PyAutoFit"
             echo "::set-output name=workspace_repository::PyAutoLabs/autofit_workspace"
             echo "::set-output name=project::autofit"
         elif [ ${{ matrix.project.name }} == "autogalaxy" ]
@@ -448,42 +448,42 @@ jobs:
         fi
 
     - uses: actions/checkout@v2
-      if: "${{ github.event.inputs.skip_notebooks != 'true' }}"
+      if: "${{ github.event.inputs.skip_notebooks != 'true' && !endsWith(matrix.project.name, '_test') }}"
       with:
           path: PyAutoBuild
     - name: Checkout project
-      if: "${{ github.event.inputs.skip_notebooks != 'true' }}"
+      if: "${{ github.event.inputs.skip_notebooks != 'true' && !endsWith(matrix.project.name, '_test') }}"
       uses: actions/checkout@v2
       with:
         repository: "${{ steps.configure.outputs.repository }}"
         path: project
     - name: Checkout workspace
-      if: "${{ github.event.inputs.skip_notebooks != 'true' }}"
+      if: "${{ github.event.inputs.skip_notebooks != 'true' && !endsWith(matrix.project.name, '_test') }}"
       uses: actions/checkout@v2
       with:
         repository: ${{ steps.configure.outputs.workspace_repository }}
         ref: main
         path: workspace
     - name: Download pre-built notebooks
-      if: "${{ github.event.inputs.skip_notebooks != 'true' }}"
+      if: "${{ github.event.inputs.skip_notebooks != 'true' && !endsWith(matrix.project.name, '_test') }}"
       uses: actions/download-artifact@v4
       with:
         name: notebooks-${{ matrix.project.name }}
         path: workspace/notebooks/
     - name: Set up Python ${{ matrix.python-version }}
-      if: "${{ github.event.inputs.skip_notebooks != 'true' }}"
+      if: "${{ github.event.inputs.skip_notebooks != 'true' && !endsWith(matrix.project.name, '_test') }}"
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install optional requirements
-      if: "${{ github.event.inputs.skip_notebooks != 'true' }}"
+      if: "${{ github.event.inputs.skip_notebooks != 'true' && !endsWith(matrix.project.name, '_test') }}"
       run: |
         echo "Installing optional requirements"
         pip install matplotlib==3.6.0
         pip install pynufft==2025.1.1
         pip install numba
     - name: Install project
-      if: "${{ github.event.inputs.skip_notebooks != 'true' }}"
+      if: "${{ github.event.inputs.skip_notebooks != 'true' && !endsWith(matrix.project.name, '_test') }}"
       run: |
         python3 -m pip install \
           --index-url https://test.pypi.org/simple/ \
@@ -491,11 +491,11 @@ jobs:
           "autoconf==${{ needs.version_number.outputs.version_number }}" \
           "${{ steps.configure.outputs.project }}==${{ needs.version_number.outputs.version_number }}"
     - name: Install Jupyter dependency
-      if: "${{ github.event.inputs.skip_notebooks != 'true' }}"
+      if: "${{ github.event.inputs.skip_notebooks != 'true' && !endsWith(matrix.project.name, '_test') }}"
       run: |
         python3 -m pip install jupyter ipynb-py-convert
     - name: Run jupyter notebooks
-      if: "${{ github.event.inputs.skip_notebooks != 'true' }}"
+      if: "${{ github.event.inputs.skip_notebooks != 'true' && !endsWith(matrix.project.name, '_test') }}"
       run: |
         export PYTHONPATH=$PYTHONPATH:$(pwd)/PyAutoBuild
         AUTOBUILD_PATH="$(pwd)/PyAutoBuild/autobuild"
@@ -503,7 +503,7 @@ jobs:
         pushd workspace
         python3 "$AUTOBUILD_PATH/run.py" ${{ matrix.project.name }} "notebooks/${{ matrix.project.directory }}" --report-dir test-results
     - name: Upload notebook results
-      if: always()
+      if: ${{ always() && !endsWith(matrix.project.name, '_test') }}
       uses: actions/upload-artifact@v4
       with:
         name: results-notebooks-${{ matrix.project.name }}-${{ matrix.project.directory }}


### PR DESCRIPTION
## Summary

Two follow-up fixes flagged during PyAutoBuild#65 review:

1. **`release.yml:420` copy-paste bug** — the `autofit` branch of the `run_notebooks` configure block set `repository::PyAutoLabs/PyAutoGalaxy`. Corrected to `PyAutoLabs/PyAutoFit`.
2. **`run_notebooks` job had no handling for `_test` workspaces** — `find_scripts` puts `autofit_test` / `autogalaxy_test` / `autolens_test` into the matrix that feeds both `run_scripts` and `run_notebooks`, but `run_notebooks` had no configure cases for them, no notebooks artifact (`generate_notebooks` doesn't process `_test` workspaces), and would fail at the artifact-download step. Every step in `run_notebooks` (and the `Upload notebook results` step) is now also gated on `!endsWith(matrix.project.name, '_test')`, mirroring how `release_workspaces` already excludes `_test`.

## Changes

- **`autofit` branch repository typo** in run_notebooks configure block (`PyAutoGalaxy` → `PyAutoFit`).
- **`_test` exclusion guard** added to all 10 `if` conditions in run_notebooks plus the `Upload notebook results` step.
  - Implementation: `if: "${{ github.event.inputs.skip_notebooks != 'true' && !endsWith(matrix.project.name, '_test') }}"`. The `Upload notebook results` step keeps `always()` to upload partial results on failure, gated as `${{ always() && !endsWith(matrix.project.name, '_test') }}`.
  - Side note: `generate_notebooks`'s skip-check `if` also got the new guard via the same string match. Its matrix is hardcoded to never include `_test` names, so the added clause is always-true there — harmless and avoids special-casing.

## Test Plan

- [x] `pytest tests/` — 57/57 passed in 1.54s.
- [x] `python3 -c "import yaml; yaml.safe_load(open('release.yml'))"` — workflow YAML parses cleanly.
- [x] grep verifies all 11 `skip_notebooks` `if` conditions now carry the `!endsWith(...)` guard; run_scripts' 8 `skip_scripts` conditions remain untouched.
- [ ] Post-merge: dispatch `release.yml` with `--field skip_release=true --field skip_scripts=true` and confirm the `run_notebooks` matrix still expands but `_test` entries skip cleanly without "artifact not found" errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
