### PR TITLE
feat(python-version): support Python 3.9-3.14, first-class 3.12/3.13

### DIFF
--- a/.github/workflows/python_matrix.yml
+++ b/.github/workflows/python_matrix.yml
@@ -1,0 +1,150 @@
+name: Python Version Matrix
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * 1'  # Monday 03:00 UTC, off-cycle from the daily release
+
+jobs:
+  unit_tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        project:
+          - { name: PyAutoConf,   tests: test_autoconf }
+          - { name: PyAutoArray,  tests: test_autoarray }
+          - { name: PyAutoFit,    tests: test_autofit }
+          - { name: PyAutoGalaxy, tests: test_autogalaxy }
+          - { name: PyAutoLens,   tests: test_autolens }
+    steps:
+      - uses: actions/checkout@v4
+        with: { repository: PyAutoLabs/PyAutoConf,   path: PyAutoConf }
+      - uses: actions/checkout@v4
+        with: { repository: PyAutoLabs/PyAutoArray,  path: PyAutoArray }
+      - uses: actions/checkout@v4
+        with: { repository: PyAutoLabs/PyAutoFit,    path: PyAutoFit }
+      - uses: actions/checkout@v4
+        with: { repository: PyAutoLabs/PyAutoGalaxy, path: PyAutoGalaxy }
+      - uses: actions/checkout@v4
+        with: { repository: PyAutoLabs/PyAutoLens,   path: PyAutoLens }
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+      - name: Install libraries (in dependency order)
+        run: |
+          python -m pip install --upgrade pip wheel
+          pip install -e ./PyAutoConf
+          pip install -e ./PyAutoArray
+          pip install -e ./PyAutoFit
+          pip install -e ./PyAutoGalaxy
+          pip install -e ./PyAutoLens
+          pip install pytest pytest-cov
+          # Install JAX-stack extras only on 3.11+ (markers gate the install)
+          pip install "./PyAutoLens[jax]"
+      - name: Run tests
+        env:
+          NUMBA_CACHE_DIR: /tmp/numba_cache
+          MPLCONFIGDIR: /tmp/matplotlib
+          JAX_ENABLE_X64: "True"
+        run: |
+          cd ${{ matrix.project.name }}
+          python -m pytest ${{ matrix.project.tests }}/ --tb=short
+
+  smoke_tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        workspace:
+          - { repo: PyAutoLabs/autofit_workspace,    path: autofit_workspace }
+          - { repo: PyAutoLabs/autogalaxy_workspace, path: autogalaxy_workspace }
+          - { repo: PyAutoLabs/autolens_workspace,   path: autolens_workspace }
+    env:
+      PYAUTO_TEST_MODE: "1"
+      PYAUTO_SMALL_DATASETS: "1"
+      PYAUTO_FAST_PLOTS: "1"
+      NUMBA_CACHE_DIR: /tmp/numba_cache
+      MPLCONFIGDIR: /tmp/matplotlib
+    steps:
+      - uses: actions/checkout@v4
+        with: { repository: PyAutoLabs/PyAutoConf,   path: PyAutoConf }
+      - uses: actions/checkout@v4
+        with: { repository: PyAutoLabs/PyAutoArray,  path: PyAutoArray }
+      - uses: actions/checkout@v4
+        with: { repository: PyAutoLabs/PyAutoFit,    path: PyAutoFit }
+      - uses: actions/checkout@v4
+        with: { repository: PyAutoLabs/PyAutoGalaxy, path: PyAutoGalaxy }
+      - uses: actions/checkout@v4
+        with: { repository: PyAutoLabs/PyAutoLens,   path: PyAutoLens }
+      - uses: actions/checkout@v4
+        with: { repository: "${{ matrix.workspace.repo }}", path: "${{ matrix.workspace.path }}" }
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+      - name: Install libraries (in dependency order)
+        run: |
+          python -m pip install --upgrade pip wheel
+          pip install -e ./PyAutoConf
+          pip install -e ./PyAutoArray
+          pip install -e ./PyAutoFit
+          pip install -e ./PyAutoGalaxy
+          pip install -e ./PyAutoLens
+          pip install -e "./PyAutoLens[jax]"
+          pip install numba
+      - name: Enable JAX_ENABLE_X64 on 3.11+
+        run: |
+          if python -c "import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)"; then
+            echo "JAX_ENABLE_X64=True" >> $GITHUB_ENV
+          fi
+      - name: Run smoke tests
+        run: |
+          cd ${{ matrix.workspace.path }}
+          if [ ! -f smoke_tests.txt ]; then
+            echo "No smoke_tests.txt found in ${{ matrix.workspace.path }} -- skipping"
+            exit 0
+          fi
+          fail=0
+          while IFS= read -r script || [ -n "$script" ]; do
+            [ -z "$script" ] && continue
+            case "$script" in \#*) continue ;; esac
+            echo "::group::$script"
+            if python "scripts/$script"; then
+              echo "PASS: $script"
+            else
+              echo "FAIL: $script"
+              fail=$((fail + 1))
+            fi
+            echo "::endgroup::"
+          done < smoke_tests.txt
+          if [ "$fail" -gt 0 ]; then
+            echo "$fail smoke test(s) failed"
+            exit 1
+          fi
+
+  summary:
+    runs-on: ubuntu-latest
+    needs: [unit_tests, smoke_tests]
+    if: always()
+    steps:
+      - name: Post summary
+        run: |
+          {
+            echo "## Python Version Matrix Results"
+            echo ""
+            echo "| Job          | Result                          |"
+            echo "|--------------|---------------------------------|"
+            echo "| unit_tests   | ${{ needs.unit_tests.result }}  |"
+            echo "| smoke_tests  | ${{ needs.smoke_tests.result }} |"
+            echo ""
+            echo "Per-cell pass/fail (Python version × project) is visible in"
+            echo "the matrix job logs above."
+            echo ""
+            echo "**Recommended:** 3.12, 3.13 (first-class)."
+            echo "**Supported with warning:** 3.9, 3.10, 3.11, 3.14."
+            echo "**JAX features:** 3.11+ only."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Build-infrastructure piece of the Python version policy change supporting Python 3.9–3.14 across PyAuto.

## Changes in this repo

- `.github/workflows/python_matrix.yml` (new): runs unit tests across `Python 3.9–3.14 × {PyAutoConf, PyAutoArray, PyAutoFit, PyAutoGalaxy, PyAutoLens}` and smoke tests across `Python 3.9–3.14 × {autofit_workspace, autogalaxy_workspace, autolens_workspace}`. Triggers: `workflow_dispatch` + weekly schedule (Monday 03:00 UTC, off-cycle from the daily release at 02:00). Posts a markdown summary table to the workflow summary.

The existing `release.yml` is untouched — fast release path stays gated on Python 3.12 only.

## Test plan

- [x] YAML parses cleanly
- [ ] Manual `workflow_dispatch` of `python_matrix.yml` after merge — this is the evidence-gathering step that proves what actually works on 3.9/3.10/3.14

This is one of 12 coordinated PRs. See sibling PRs on `feature/python-version-policy` in the 5 PyAuto libraries and the 6 workspace repos.