### PR TITLE
pre_build: forward SKIP_SCRIPTS / SKIP_NOTEBOOKS to release dispatch

### DIFF
--- a/pre_build.sh
+++ b/pre_build.sh
@@ -6,11 +6,17 @@
 # Usage: bash pre_build.sh [minor_version] [skip_release]
 #   minor_version  Minor version suffix (default: 1)
 #   skip_release   Whether to skip the release stage, true or false (default: false)
+#
+# Optional env vars (forwarded as workflow_dispatch inputs when set):
+#   SKIP_SCRIPTS    true|false — skip run_scripts matrix in release.yml
+#   SKIP_NOTEBOOKS  true|false — skip run_notebooks matrix in release.yml
 
 set -e
 
 MINOR_VERSION="${1:-1}"
 SKIP_RELEASE="${2:-false}"
+SKIP_SCRIPTS="${SKIP_SCRIPTS:-}"
+SKIP_NOTEBOOKS="${SKIP_NOTEBOOKS:-}"
 PYAUTOBASE="/mnt/c/Users/Jammy/Code/PyAutoLabs"
 AUTOBUILD="$PYAUTOBASE/PyAutoBuild/autobuild"
 PYTHONPATH_EXTRA="$AUTOBUILD"
@@ -110,10 +116,18 @@ bash "$PYAUTOBASE/PyAutoBuild/verify_workspace_versions.sh"
 # Trigger the GitHub Actions release workflow
 echo ""
 echo "=== Triggering release workflow (minor_version=$MINOR_VERSION) ==="
+EXTRA_FIELDS=()
+if [ -n "$SKIP_SCRIPTS" ]; then
+    EXTRA_FIELDS+=(--field "skip_scripts=$SKIP_SCRIPTS")
+fi
+if [ -n "$SKIP_NOTEBOOKS" ]; then
+    EXTRA_FIELDS+=(--field "skip_notebooks=$SKIP_NOTEBOOKS")
+fi
 gh workflow run release.yml \
     --repo PyAutoLabs/PyAutoBuild \
     --field minor_version="$MINOR_VERSION" \
-    --field skip_release="$SKIP_RELEASE"
+    --field skip_release="$SKIP_RELEASE" \
+    "${EXTRA_FIELDS[@]}"
 
 echo ""
 echo "Pre-build complete. Workflow dispatched."


### PR DESCRIPTION
## Summary

- Add optional `SKIP_SCRIPTS` / `SKIP_NOTEBOOKS` env vars to `pre_build.sh`, forwarded as `--field skip_scripts=… --field skip_notebooks=…` to `gh workflow run release.yml`.
- Empty / unset → `--field` omitted entirely → `release.yml` defaults (`false`) apply. No behaviour change for any current caller.

## Why

`release.yml` already accepts `skip_scripts` and `skip_notebooks` workflow_dispatch inputs, but `pre_build.sh` never forwarded them. When the workspace `version.txt` pins lag the next release version (the steady state of every "first release after a few weeks"), `run_scripts` / `run_notebooks` fail on `WorkspaceVersionMismatchError` and gate the `release` job indefinitely. Letting `/pre_build` set both flags makes the canonical recovery path (`SKIP_SCRIPTS=true SKIP_NOTEBOOKS=true bash pre_build.sh 1`) a single command.

## Test plan

- [ ] `bash -n pre_build.sh` — passes (verified locally).
- [ ] Run `SKIP_SCRIPTS=true SKIP_NOTEBOOKS=true bash pre_build.sh 1` end-to-end on the dispatch box; confirm the resulting `gh run list` entry has both `skip_scripts=true` and `skip_notebooks=true` recorded as inputs.
- [ ] Run `bash pre_build.sh 1` (no env vars) to confirm the original two-arg flow still dispatches with defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)