### PR TITLE
pre_build: derive PYAUTOBASE from script location

### DIFF
--- a/pre_build.sh
+++ b/pre_build.sh
@@ -17,7 +17,11 @@ MINOR_VERSION="${1:-1}"
 SKIP_RELEASE="${2:-false}"
 SKIP_SCRIPTS="${SKIP_SCRIPTS:-}"
 SKIP_NOTEBOOKS="${SKIP_NOTEBOOKS:-}"
-PYAUTOBASE="/mnt/c/Users/Jammy/Code/PyAutoLabs"
+
+# Resolve PYAUTOBASE from this script's location (same idiom as bin/autobuild)
+# so pre_build.sh works from any checkout — Linux, WSL, anywhere.
+SELF="$(readlink -f "$0")"
+PYAUTOBASE="$(cd "$(dirname "$SELF")/.." && pwd)"
 AUTOBUILD="$PYAUTOBASE/PyAutoBuild/autobuild"
 PYTHONPATH_EXTRA="$AUTOBUILD"
 


### PR DESCRIPTION
## Summary

Replace the hardcoded `PYAUTOBASE=/mnt/c/Users/Jammy/Code/PyAutoLabs` (an old WSL-via-Windows path) with the same script-relative derivation `bin/autobuild` already uses:

```bash
SELF="$(readlink -f "$0")"
PYAUTOBASE="$(cd "$(dirname "$SELF")/.." && pwd)"
```

## Why

All current work lives at `/home/jammy/Code/PyAutoLabs` (Linux-native checkouts). The hardcode meant `pre_build.sh` only worked from one specific WSL setup — agents, CI, and any other Linux-native checkout would fail at the first `bash "$PYAUTOBASE/..."` call. Script-relative resolution makes the script portable with no env-var dance.

## Test plan

- [x] `bash -n pre_build.sh` — syntax OK.
- [x] Eval the new derivation in isolation: resolves `PYAUTOBASE` to the directory containing `PyAutoBuild/` and `admin_jammy/`.
- [ ] Run `SKIP_SCRIPTS=true SKIP_NOTEBOOKS=true bash pre_build.sh 1` end-to-end to confirm the workspace loop and the dispatch step both find their paths correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)