### PR TITLE
pre_build: only stage dataset/ if it exists

### DIFF
--- a/pre_build.sh
+++ b/pre_build.sh
@@ -65,7 +65,7 @@ run_workspace() {
     fi
 
     echo "  Staging safe directories..."
-    git add -f dataset/
+    [ -d dataset ] && git add -f dataset/
     for d in config notebooks scripts; do
         [ -d "$d" ] && git add "$d/"
     done


### PR DESCRIPTION
## Summary

Make `git add -f dataset/` conditional on the directory existing. Workspaces without a `dataset/` (HowToFit, HowToGalaxy) hit `fatal: pathspec 'dataset/' did not match any files` and abort under `set -e`.

Matches the existing conditional pattern used for `config/`, `notebooks/`, and `scripts/` two lines below.

## Why

While running `SKIP_SCRIPTS=true SKIP_NOTEBOOKS=true bash pre_build.sh 1` against all 10 workspaces, the script aborted at HowToGalaxy because that repo has no `dataset/` folder. This interrupted the release-dispatch flow before HowToLens, HowToFit, the PyAutoBuild self-commit, version verification, or `gh workflow run` ever ran.

## Test plan

- [x] `bash -n pre_build.sh` — syntax OK.
- [ ] Re-run `SKIP_SCRIPTS=true SKIP_NOTEBOOKS=true bash pre_build.sh 1` end-to-end, confirm HowToGalaxy / HowToFit / HowToLens all complete and the workflow dispatches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)