### PR TITLE
release: fail-fast=false on release_workspaces, drop euclid_pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -692,6 +692,7 @@ jobs:
       - release_test_pypi
       - version_number
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.12]
         workspace:
@@ -725,11 +726,13 @@ jobs:
             package: PyAutoFit
             generate_notebooks: true
             bump_colab_urls: true
-          - repository: Jammy2211/euclid_strong_lens_modeling_pipeline
-            name: euclid_pipeline
-            package: PyAutoLens
-            generate_notebooks: false
-            bump_colab_urls: false
+          # NOTE: Jammy2211/euclid_strong_lens_modeling_pipeline removed from
+          # release_workspaces matrix because PAT_PYAUTOLABS does not have
+          # write access to repos in the Jammy2211/ user namespace. To
+          # re-enable, add a PAT_JAMMY repo secret with contents:write on
+          # the euclid repo and re-add the matrix entry with `pat: PAT_JAMMY`
+          # following the per-matrix pat pattern used in the `release` job
+          # (lines 575–597). Until then, tag euclid manually on releases.
     steps:
     - uses: actions/checkout@v2
       if: "${{ github.event.inputs.skip_release != 'true' }}"


### PR DESCRIPTION
## Summary

Two fixes to `release_workspaces` matrix in `release.yml`:

1. **Add `fail-fast: false`.** Default fail-fast cancelled 5 sibling matrix jobs when euclid_pipeline auth-failed in run [25211061207](https://github.com/PyAutoLabs/PyAutoBuild/actions/runs/25211061207) (release of 2026.5.1.1) — leaving 5 of 7 workspaces un-tagged.

2. **Remove the `Jammy2211/euclid_strong_lens_modeling_pipeline` matrix entry.** `PAT_PYAUTOLABS` is scoped to the `PyAutoLabs/` org and cannot push to a repo in the `Jammy2211/` user namespace. The job has been failing on every release for that one matrix item with `Permission to Jammy2211/euclid_strong_lens_modeling_pipeline.git denied to Jammy2211 → exit 128`.

## To re-enable euclid auto-tagging later

1. Create a fine-grained PAT scoped to `Jammy2211` with `contents: write` on `euclid_strong_lens_modeling_pipeline`.
2. Add it as `PAT_JAMMY` repo secret on `PyAutoLabs/PyAutoBuild`.
3. Re-add the matrix entry with a `pat: PAT_JAMMY` field, mirroring the per-matrix `pat` pattern in the `release` job (release.yml lines 575–597).

Until then, tag `euclid_pipeline` manually whenever it should pin to a new lib version.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('release.yml'))"` passes (verified locally).
- [ ] Dispatch release with `minor_version=2 skip_scripts=true skip_notebooks=true`. All 6 remaining `release_workspaces` matrix items run to success or fail independently of each other; tags `2026.5.1.2` push to all 6 workspace repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)