### PR TITLE
release: bump release_test_pypi wait timeout 100→300 attempts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,15 +105,21 @@ jobs:
             export PACKAGES=("autoconf" "autoarray" "autofit" "autogalaxy" "autolens")
             export VERSION="${{ needs.version_number.outputs.version_number }}"
 
-            # Wait for each package to become available on test PyPI
+            # Wait for each package to become available on test PyPI.
+            # 300 attempts × 10s = 50min buffer. Each release_test_pypi matrix
+            # job uploads its own lib then waits for ALL 5 to be visible on the
+            # simple index, so the wait must absorb the slowest sibling build —
+            # on slow CI days the previous 100 × 10s = 17min budget timed out
+            # waiting for siblings that hadn't finished uploading yet, which
+            # then cascade-cancelled the rest of the matrix.
             for PACKAGE in ${PACKAGES[@]}; do
               echo "Checking for $PACKAGE==$VERSION on test PyPI..."
               cnt=0
               until python3 -m pip download --no-deps --dest /tmp/pyauto-check \
                     --index-url https://test.pypi.org/simple/ "$PACKAGE==$VERSION" 2>/dev/null; do
                 ((cnt=cnt+1))
-                if [[ $cnt -ge 100 ]]; then
-                  echo "ERROR: Timed out waiting for $PACKAGE==$VERSION after 100 attempts"
+                if [[ $cnt -ge 300 ]]; then
+                  echo "ERROR: Timed out waiting for $PACKAGE==$VERSION after 300 attempts (50min)"
                   exit 1
                 fi
                 echo "  Waiting for $PACKAGE==$VERSION... (attempt $cnt)"


### PR DESCRIPTION
## Summary

Bump the `Wait for packages and install` timeout in `release_test_pypi` from 100 attempts to 300 (10s sleep each → 17min → 50min budget).

## Why

Each `release_test_pypi` matrix job uploads its own lib to TestPyPI, then waits in a loop for ALL 5 libs to become visible on the simple index. The wait budget must absorb the slowest sibling build.

Run [25211639079](https://github.com/PyAutoLabs/PyAutoBuild/actions/runs/25211639079) (release of 2026.5.1.2) failed because autofit's wait loop hit the 100×10s=17min timeout before autoarray became visible. With default fail-fast, the timeout cascade-cancelled the other 4 release_test_pypi jobs mid-build. 2026.5.1.2 ended up uploaded to TestPyPI but never published to real PyPI.

## Long-term cleanup

The race condition could be eliminated entirely by splitting `release_test_pypi` into two jobs: a matrix `upload_test_pypi` (upload only, no wait) and a single `install_and_test_pypi` that waits once and tests against all 5 from one resolver. Out of scope here.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('release.yml'))"` passes.
- [ ] Re-dispatch with `minor_version=3` (since TestPyPI already has 2026.5.1.2 from the failed run); verify all 5 release_test_pypi complete and the release job uploads to real PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)