### PR TITLE
release: retry install command in release_test_pypi for CDN flakiness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,14 +133,29 @@ jobs:
             # pinned. This prevents pip from substituting unrelated packages with
             # the same names from production PyPI (e.g. autoconf 0.7.7, autofit 0.73.1)
             # during dependency resolution.
-            python3 -m pip install \
-              --index-url https://test.pypi.org/simple/ \
-              --extra-index-url https://pypi.org/simple \
-              "autoconf[optional]==$VERSION" \
-              "autoarray[optional]==$VERSION" \
-              "autofit[optional]==$VERSION" \
-              "autogalaxy[optional]==$VERSION" \
-              "autolens[optional]==$VERSION"
+            #
+            # Retry the install command — TestPyPI's simple index has CDN
+            # consistency issues. The wait loop above can succeed for a version
+            # that the install (which also queries real PyPI via --extra-index-url)
+            # then fails to resolve, because different requests hit different CDN
+            # edges with different views. Retry with backoff to ride out the lag.
+            install_cnt=0
+            until python3 -m pip install \
+                  --index-url https://test.pypi.org/simple/ \
+                  --extra-index-url https://pypi.org/simple \
+                  "autoconf[optional]==$VERSION" \
+                  "autoarray[optional]==$VERSION" \
+                  "autofit[optional]==$VERSION" \
+                  "autogalaxy[optional]==$VERSION" \
+                  "autolens[optional]==$VERSION"; do
+              ((install_cnt=install_cnt+1))
+              if [[ $install_cnt -ge 30 ]]; then
+                echo "ERROR: Install failed after 30 attempts (5min)"
+                exit 1
+              fi
+              echo "  Install attempt $install_cnt failed, retrying in 10s..."
+              sleep 10
+            done
         - name: Tests
           run: |
             pushd "${{ matrix.project.path }}"


### PR DESCRIPTION
## Summary

Wrap the `pip install` step in `release_test_pypi`'s "Wait for packages and install" inside a 30-attempt × 10s retry loop. Handles transient TestPyPI simple-index CDN inconsistency.

## Why

Run [25212260809](https://github.com/PyAutoLabs/PyAutoBuild/actions/runs/25212260809) (release of 2026.5.1.3) failed with `No matching distribution found for autolens==2026.5.1.3` 0.3 seconds after the wait loop succeeded for the same version. A clean-venv repro of the same install command from a different host *right now* succeeds — the package is fully uploaded, but TestPyPI's CDN edges are inconsistent at the moment a new version becomes live.

Wait loop only confirms one CDN edge sees the version. The install command's HTTP requests can hit other edges that haven't propagated yet. Retrying lets it ride out the lag without burning another version slot per release.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('release.yml'))"` passes locally.
- [ ] Re-dispatch with `minor_version=4` (TestPyPI already has 2026.5.1.3 from the failed run) — install should succeed on first attempt or retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)