### PR TITLE
release: re-enable euclid_pipeline in release_workspaces (now under PyAutoLabs/)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -747,13 +747,11 @@ jobs:
             package: PyAutoFit
             generate_notebooks: true
             bump_colab_urls: true
-          # NOTE: Jammy2211/euclid_strong_lens_modeling_pipeline removed from
-          # release_workspaces matrix because PAT_PYAUTOLABS does not have
-          # write access to repos in the Jammy2211/ user namespace. To
-          # re-enable, add a PAT_JAMMY repo secret with contents:write on
-          # the euclid repo and re-add the matrix entry with `pat: PAT_JAMMY`
-          # following the per-matrix pat pattern used in the `release` job
-          # (lines 575–597). Until then, tag euclid manually on releases.
+          - repository: PyAutoLabs/euclid_strong_lens_modeling_pipeline
+            name: euclid_pipeline
+            package: PyAutoLens
+            generate_notebooks: false
+            bump_colab_urls: false
     steps:
     - uses: actions/checkout@v2
       if: "${{ github.event.inputs.skip_release != 'true' }}"


### PR DESCRIPTION
## Summary

Re-add `PyAutoLabs/euclid_strong_lens_modeling_pipeline` to the `release_workspaces` matrix in `release.yml`. The repository was transferred from `Jammy2211/` to `PyAutoLabs/` today, so `PAT_PYAUTOLABS` (org-scoped) now has the write access needed to push tags and version bumps.

Reverses [PR #78](https://github.com/PyAutoLabs/PyAutoBuild/pull/78)'s removal, which was a temporary workaround while the repo lived in the `Jammy2211/` user namespace.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('release.yml'))"` passes locally.
- [ ] Next release dispatch should produce 7 `release_workspaces` matrix entries (6 PyAutoLabs/* workspaces + euclid), all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)