### PR TITLE
release: skip workspace version check in run_smoke_tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,6 +184,7 @@ jobs:
       PYAUTO_TEST_MODE: "1"
       PYAUTO_SMALL_DATASETS: "1"
       PYAUTO_FAST_PLOTS: "1"
+      PYAUTO_SKIP_WORKSPACE_VERSION_CHECK: "1"
       NUMBA_CACHE_DIR: /tmp/numba_cache
       MPLCONFIGDIR: /tmp/matplotlib
       JAX_ENABLE_X64: "True"


### PR DESCRIPTION
## Summary

The `run_smoke_tests` job from PR #83 fails with `WorkspaceVersionMismatchError` because it checks out workspaces from `main` (still pinned at the previous release version, e.g. `2026.5.1.4`) but installs the just-built library version (`2026.5.8.1`). The library's import-time version check rejects every script.

Fix: set `PYAUTO_SKIP_WORKSPACE_VERSION_CHECK=1` in the job env. This is the exact escape hatch the runtime error message recommends for users who track `main` instead of release tags — and that is precisely what smoke_tests does (it must run before `release_workspaces`, which is what would update the workspace version pin).

## API Changes

None.

## Scripts Changed

None — workflow env only.

## Test plan

- [x] YAML parses
- [ ] Next release dispatch: confirm `run_smoke_tests` matrix cells go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)