### PR TITLE
config: remove ellipse/database from autogalaxy no_run fallback

### DIFF
--- a/autobuild/config/no_run.yaml
+++ b/autobuild/config/no_run.yaml
@@ -14,7 +14,6 @@ autogalaxy:
 - gui/extra_galaxies_centres # GUI scripts cannot be run
 - examples/searches # Test mode breaks search visualization.
 - data_fitting # Test mode breaks .fits file output
-- ellipse/database # Ellipse model needs refactor and JAX support
 autolens:
 - tutorial_searches
 - tutorial_5_borders # Cant get right masks, need proper update.


### PR DESCRIPTION
## Summary

Remove the `ellipse/database` entry from the `autogalaxy:` section of `autobuild/config/no_run.yaml`. This was the fallback skip rule for the script when the ellipse refactor was outstanding. With PyAutoGalaxy #408 / #410 / #412 (ellipse JAX refactor, merged 2026-05-14) and PyAutoFit #1270 (Drawer `from_dict` fix) shipped, `autogalaxy_workspace/scripts/ellipse/database.py` now runs cleanly under `PYAUTO_TEST_MODE=2` and the fallback is no longer needed.

Paired with the autogalaxy_workspace PR that removes the same script from its `config/build/no_run.yaml`.

## Files Changed

- `autobuild/config/no_run.yaml` — remove `- ellipse/database # Ellipse model needs refactor and JAX support` from the `autogalaxy:` section

## Upstream PR

- https://github.com/PyAutoLabs/PyAutoFit/pull/1270 — paired Drawer `from_dict` fix

## Test Plan

- [x] Config-only change; verified by re-running `autogalaxy_workspace/scripts/ellipse/database.py` under `PYAUTO_TEST_MODE=2` with the entry removed
- [x] PyAutoBuild unit tests (`tests/`) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)