### PR TITLE
release.yml: skip PyAutoFit NSS tests in release_test_pypi pytest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,16 @@ jobs:
             pip install pynufft==2025.1.1
             pip install pytest
             pip install numba
-            python3 -m pytest
+            # PyAutoFit's NSS tests need the handley-lab blackjax fork +
+            # yallup/nss, which can't live in the [nss] extra because
+            # PyPI bans direct git+ URLs in uploaded wheels. They're tested
+            # separately in PyAutoFit's own unittest_nss job. Here we only
+            # exercise the TestPyPI-installable surface, so skip them.
+            if [ "${{ matrix.project.path }}" = "PyAutoFit" ]; then
+              python3 -m pytest --ignore=test_autofit/non_linear/search/nest/nss
+            else
+              python3 -m pytest
+            fi
 
   run_smoke_tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

In `release_test_pypi`'s pytest step, skip `test_autofit/non_linear/search/nest/nss/` when the project is PyAutoFit. All other projects run the full pytest suite as before.

## Why

PyAutoFit's NSS tests need the handley-lab blackjax fork and yallup/nss, which were just removed from the [nss] pyproject.toml extra (PR PyAutoLabs/PyAutoFit#1286) because PyPI/TestPyPI reject direct `git+https://` URLs in wheel metadata. The fork deps now require a manual `pip install git+...` step after `pip install autofit[nss]`.

`release_test_pypi` installs from TestPyPI without that manual step (it's testing the wheel-install surface), so the NSS tests fail at import time:

```
ImportError: af.NSS requires the optional `nss` package and the matching `handley-lab/blackjax` fork
```

The NSS path is already exercised in PyAutoFit's own `unittest_nss` job, which installs the fork deps explicitly.

## Test plan

- [x] Local syntax: `yamllint` / GitHub-actions VS Code extension green (only single-quoted bash conditional added)
- [ ] CI: re-dispatch `release.yml` with `skip_release=true skip_scripts=true skip_notebooks=true minor_version=0`. release_test_pypi should now go fully green.

## Companion PRs

- PyAutoLabs/PyAutoFit#1286 (merged, today) — the [nss] git+ URL strip that unmasked this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)