### PR TITLE
verify_workspace_versions: tail -n 1 to ignore JAX cuda warning on stdout

### DIFF
--- a/verify_workspace_versions.sh
+++ b/verify_workspace_versions.sh
@@ -131,7 +131,12 @@ for entry in "${WORKSPACES[@]}"; do
             ;;
     esac
 
-    if ! lib_version=$(python3 -c "import $pkg; print($pkg.__version__)" 2>/dev/null); then
+    # JAX's `jax_plugins.xla_cuda12 - WARNING - cuda_plugin_extension is not
+    # found` log line writes to STDOUT (not stderr) on machines where the cuda
+    # plugin extension can't be loaded — most laptop dev environments. Without
+    # `tail -n 1`, that warning prefixes the printed version string and the
+    # downstream parser fails with "could not parse versions".
+    if ! lib_version=$(python3 -c "import $pkg; print($pkg.__version__)" 2>/dev/null | tail -n 1); then
         printf "  %-45s SKIP (cannot import %s)\n" "$ws" "$pkg"
         continue
     fi


### PR DESCRIPTION
## Summary

`tail -n 1` the python-import output that reads `<pkg>.__version__`, so the JAX `jax_plugins.xla_cuda12 - WARNING - cuda_plugin_extension is not found.` log line (which goes to STDOUT, not stderr) doesn't leak into the captured version string.

## Why

This blocked pre_build dispatch on a laptop today — the JAX warning prefixed every captured version with a multi-line log entry, and the downstream comparison reported "could not parse versions" for every JAX-using workspace (autogalaxy_workspace, autolens_workspace, HowToGalaxy, HowToLens, euclid_strong_lens_modeling_pipeline).

CI is unaffected: ubuntu-latest runners can load the cuda plugin cleanly so the warning never fires.

## Test plan

- [x] Locally reproduced the bug
- [x] Applied the patch — all 7 workspaces now show `ok` against an installed library at 2026.5.14.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)