### PR TITLE
feat(run_all): include HowTo + euclid pipeline in workspace triage

### DIFF
--- a/autobuild/build_util.py
+++ b/autobuild/build_util.py
@@ -205,8 +205,10 @@ def execute_notebooks_in_folder(
             execute_notebook(file, report=report, env=env)
 
 
-def execute_script(f, report=None, env=None):
+def execute_script(f, report=None, env=None, extra_args=None):
     args = [BUILD_PYTHON_INTERPRETER, f]
+    if extra_args:
+        args.extend(extra_args)
     script_name = Path(f).relative_to(Path.cwd()) if Path(f).is_relative_to(Path.cwd()) else Path(f).name
     print(f"  {script_name} ...", end=" ", flush=True)
 
@@ -335,6 +337,7 @@ def execute_scripts_in_folder(directory, no_run_list=None, report=None, skip_rea
                     skip_reason=reason,
                 ))
         else:
-            from env_config import build_env_for_script
+            from env_config import build_env_for_script, args_for_script
             env = build_env_for_script(file, env_config)
-            execute_script(str(file), report=report, env=env)
+            extra_args = args_for_script(file, env_config)
+            execute_script(str(file), report=report, env=env, extra_args=extra_args)

--- a/autobuild/env_config.py
+++ b/autobuild/env_config.py
@@ -5,6 +5,7 @@ applying defaults and per-pattern overrides.
 """
 
 import os
+import shlex
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -54,6 +55,30 @@ def build_env_for_script(
                 env[key] = str(value)
 
     return env
+
+
+def args_for_script(
+    file: Path,
+    env_config: Optional[dict],
+) -> List[str]:
+    """Return CLI args to append after the script path, based on env_config.
+
+    Reads the ``args_default`` field of env_vars.yaml — a single string
+    that is shlex-split into argv tokens and appended to every
+    ``python <script>`` invocation. Used by workspaces whose scripts
+    require CLI args (e.g. euclid needs ``--dataset`` and ``--sample``).
+    Mirrors the semantics of ``args_default`` in the ``/smoke_test`` skill.
+
+    Returns ``[]`` when env_config is None, args_default is missing, or
+    args_default is empty/whitespace — making this a no-op for every
+    workspace that does not opt in.
+    """
+    if env_config is None:
+        return []
+    raw = env_config.get("args_default", "")
+    if not raw or not str(raw).strip():
+        return []
+    return shlex.split(str(raw))
 
 
 def _pattern_matches(file: Path, pattern: str) -> bool:

--- a/autobuild/run_all.py
+++ b/autobuild/run_all.py
@@ -3,10 +3,11 @@
 Run workspace scripts across one or more workspaces and produce summary reports.
 
 Usage:
-    python run_all.py                          # all 9 workspaces
+    python run_all.py                          # all 10 workspaces
     python run_all.py autolens                 # just autolens_workspace
     python run_all.py autolens_test autofit    # specific workspaces
     python run_all.py howtolens                # just HowToLens
+    python run_all.py euclid                   # just the Euclid pipeline
 
 Reports default to <autobuild>/../test_results/runs/<UTC-timestamp>/ with a
 sibling `latest` symlink pointing at the most recent successful run, so every
@@ -41,6 +42,7 @@ WORKSPACES = {
     "howtofit": ("HowToFit", "howtofit"),
     "howtogalaxy": ("HowToGalaxy", "howtogalaxy"),
     "howtolens": ("HowToLens", "howtolens"),
+    "euclid": ("euclid_strong_lens_modeling_pipeline", "euclid"),
 }
 
 DEFAULT_TIMEOUT_SECS = 300
@@ -81,6 +83,9 @@ def run_workspace(name, workspace_dir, project, results_dir, python, timeout_sec
         p.name for p in scripts_dir.iterdir()
         if p.is_dir() and p.name != "__pycache__"
     )
+    # Flat scripts/ (e.g. euclid_strong_lens_modeling_pipeline) → run the
+    # directory itself as a single unit rather than iterating subdirs.
+    iter_dirs = directories or [""]
 
     # Ensure child processes (run_python.py -> build_util.py) use the same
     # interpreter and timeout for running scripts.
@@ -89,8 +94,8 @@ def run_workspace(name, workspace_dir, project, results_dir, python, timeout_sec
     env["BUILD_SCRIPT_TIMEOUT"] = str(timeout_secs)
     env["PYTHONUNBUFFERED"] = "1"
 
-    for directory in directories:
-        rel_dir = f"scripts/{directory}"
+    for directory in iter_dirs:
+        rel_dir = "scripts" if directory == "" else f"scripts/{directory}"
         print(f"\n  Running {name} / {rel_dir} ...")
         cmd = [
             python,

--- a/autobuild/run_all.py
+++ b/autobuild/run_all.py
@@ -3,9 +3,10 @@
 Run workspace scripts across one or more workspaces and produce summary reports.
 
 Usage:
-    python run_all.py                          # all 6 workspaces
+    python run_all.py                          # all 9 workspaces
     python run_all.py autolens                 # just autolens_workspace
     python run_all.py autolens_test autofit    # specific workspaces
+    python run_all.py howtolens                # just HowToLens
 
 Reports default to <autobuild>/../test_results/runs/<UTC-timestamp>/ with a
 sibling `latest` symlink pointing at the most recent successful run, so every
@@ -37,6 +38,9 @@ WORKSPACES = {
     "autofit_test": ("autofit_workspace_test", "autofit_test"),
     "autogalaxy_test": ("autogalaxy_workspace_test", "autogalaxy_test"),
     "autolens_test": ("autolens_workspace_test", "autolens_test"),
+    "howtofit": ("HowToFit", "howtofit"),
+    "howtogalaxy": ("HowToGalaxy", "howtogalaxy"),
+    "howtolens": ("HowToLens", "howtolens"),
 }
 
 DEFAULT_TIMEOUT_SECS = 300

--- a/bin/autobuild
+++ b/bin/autobuild
@@ -259,8 +259,8 @@ reports.
 
 Arguments (positional):
   autofit | autogalaxy | autolens | autofit_test | autogalaxy_test | autolens_test
-  | howtofit | howtogalaxy | howtolens
-  (default: all nine)
+  | howtofit | howtogalaxy | howtolens | euclid
+  (default: all ten)
 
 Options:
   --results-dir    Override default output dir (default:

--- a/bin/autobuild
+++ b/bin/autobuild
@@ -259,7 +259,8 @@ reports.
 
 Arguments (positional):
   autofit | autogalaxy | autolens | autofit_test | autogalaxy_test | autolens_test
-  (default: all six)
+  | howtofit | howtogalaxy | howtolens
+  (default: all nine)
 
 Options:
   --results-dir    Override default output dir (default:

--- a/tests/test_env_config.py
+++ b/tests/test_env_config.py
@@ -1,0 +1,49 @@
+"""Unit tests for autobuild/env_config.py — args_for_script() in particular.
+
+build_env_for_script() is exercised indirectly by
+test_workspace_config_precedence.py; here we focus on the args_default
+plumbing added for workspaces whose scripts require CLI args (euclid).
+"""
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+AUTOBUILD_DIR = PROJECT_ROOT / "autobuild"
+sys.path.insert(0, str(AUTOBUILD_DIR))
+
+from env_config import args_for_script  # noqa: E402
+
+
+FAKE_FILE = Path("scripts/fake.py")
+
+
+def test_args_for_script_none_env_config_returns_empty():
+    assert args_for_script(FAKE_FILE, None) == []
+
+
+def test_args_for_script_missing_key_returns_empty():
+    assert args_for_script(FAKE_FILE, {"defaults": {"FOO": "bar"}}) == []
+
+
+def test_args_for_script_empty_string_returns_empty():
+    assert args_for_script(FAKE_FILE, {"args_default": ""}) == []
+
+
+def test_args_for_script_whitespace_only_returns_empty():
+    assert args_for_script(FAKE_FILE, {"args_default": "   \t  "}) == []
+
+
+def test_args_for_script_simple_args():
+    assert args_for_script(
+        FAKE_FILE,
+        {"args_default": "--dataset=foo --sample=bar"},
+    ) == ["--dataset=foo", "--sample=bar"]
+
+
+def test_args_for_script_quoted_arg_with_space():
+    # shlex.split honours quoting so values containing spaces stay together.
+    assert args_for_script(
+        FAKE_FILE,
+        {"args_default": '--name="a b" --flag'},
+    ) == ["--name=a b", "--flag"]

--- a/tests/test_run_all_history.py
+++ b/tests/test_run_all_history.py
@@ -17,8 +17,8 @@ sys.path.insert(0, str(AUTOBUILD_DIR))
 import run_all  # noqa: E402
 
 
-def test_workspaces_dict_has_nine_entries():
-    """All 9 active workspaces (6 main + 3 HowTo lectures) must be enumerable."""
+def test_workspaces_dict_has_ten_entries():
+    """All 10 active workspaces (6 main + 3 HowTo + euclid pipeline) must be enumerable."""
     expected = {
         "autofit",
         "autogalaxy",
@@ -29,12 +29,15 @@ def test_workspaces_dict_has_nine_entries():
         "howtofit",
         "howtogalaxy",
         "howtolens",
+        "euclid",
     }
     assert set(run_all.WORKSPACES.keys()) == expected
     assert run_all.WORKSPACES["autogalaxy_test"][0] == "autogalaxy_workspace_test"
     assert run_all.WORKSPACES["autogalaxy_test"][1] == "autogalaxy_test"
     assert run_all.WORKSPACES["howtolens"][0] == "HowToLens"
     assert run_all.WORKSPACES["howtolens"][1] == "howtolens"
+    assert run_all.WORKSPACES["euclid"][0] == "euclid_strong_lens_modeling_pipeline"
+    assert run_all.WORKSPACES["euclid"][1] == "euclid"
 
 
 def test_default_timeout_is_300():

--- a/tests/test_run_all_history.py
+++ b/tests/test_run_all_history.py
@@ -17,8 +17,8 @@ sys.path.insert(0, str(AUTOBUILD_DIR))
 import run_all  # noqa: E402
 
 
-def test_workspaces_dict_has_six_entries():
-    """All 6 active workspaces (including autogalaxy_test) must be enumerable."""
+def test_workspaces_dict_has_nine_entries():
+    """All 9 active workspaces (6 main + 3 HowTo lectures) must be enumerable."""
     expected = {
         "autofit",
         "autogalaxy",
@@ -26,10 +26,15 @@ def test_workspaces_dict_has_six_entries():
         "autofit_test",
         "autogalaxy_test",
         "autolens_test",
+        "howtofit",
+        "howtogalaxy",
+        "howtolens",
     }
     assert set(run_all.WORKSPACES.keys()) == expected
     assert run_all.WORKSPACES["autogalaxy_test"][0] == "autogalaxy_workspace_test"
     assert run_all.WORKSPACES["autogalaxy_test"][1] == "autogalaxy_test"
+    assert run_all.WORKSPACES["howtolens"][0] == "HowToLens"
+    assert run_all.WORKSPACES["howtolens"][1] == "howtolens"
 
 
 def test_default_timeout_is_300():


### PR DESCRIPTION
## Summary

- Extend `autobuild run_all` from 6 to 10 workspaces: adds `howtofit`, `howtogalaxy`, `howtolens`, and `euclid` so local pre-release triage covers the full release surface (the same set already handled by `pre_build.sh`).
- Thread `args_default` (YAML field already documented in `/smoke_test`) through `env_config.args_for_script` → `build_util.execute_script(extra_args=...)`. No-op for every workspace that doesn't opt in; unblocks euclid scripts which need `--dataset` / `--sample`.
- Generalise `run_workspace` to fall back to running `scripts/` itself when it has no chapter subdirs — covers euclid's flat layout and any future flat-scripts workspace.

## Test plan

- [x] `pytest` — full PyAutoBuild suite (78 tests pass, including new `test_env_config.py` covering 6 args_default edge cases and the bumped 10-entry assertion in `test_run_all_history.py`).
- [x] `autobuild help run_all` — choices line now lists all ten workspaces.
- [x] `autobuild run_all euclid --timeout-secs 120` — 5/5 scripts PASS (29–97s each) under the existing `PYAUTO_TEST_MODE=2` fast path; confirms flat-scripts + args_default plumbing end-to-end.
- [ ] Reviewer to spot-check `args_for_script` signature mirrors `build_env_for_script` for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)