### PR TITLE
feat: auto-refresh autolens_assistant API baseline in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -837,6 +837,12 @@ jobs:
             package: PyAutoLens
             generate_notebooks: false
             bump_colab_urls: false
+          - repository: PyAutoLabs/autolens_assistant
+            name: autolens
+            package: PyAutoLens
+            generate_notebooks: false
+            bump_colab_urls: false
+            write_api_baseline: true
     steps:
     - uses: actions/checkout@v2
       if: "${{ github.event.inputs.skip_release != 'true' }}"
@@ -905,6 +911,39 @@ jobs:
         PY
         git add version.txt config/general.yaml 2>/dev/null || git add version.txt
         git commit -m "Release $VERSION: pin workspace version" || true
+    - name: Regenerate API audit baseline
+      if: "${{ github.event.inputs.skip_release != 'true' && matrix.workspace.write_api_baseline == true }}"
+      env:
+        NUMBA_CACHE_DIR: /tmp/numba_cache
+        MPLCONFIGDIR: /tmp/matplotlib
+        PYAUTO_SKIP_WORKSPACE_VERSION_CHECK: "1"
+      run: |
+        VERSION="${{ needs.version_number.outputs.version_number }}"
+        # Install the just-released wheels so the baseline hashes the published
+        # API surface, then let the assistant regenerate its own baseline (it
+        # owns the hash format — no reimplementation here).
+        install_cnt=0
+        until python3 -m pip install \
+              --index-url https://test.pypi.org/simple/ \
+              --extra-index-url https://pypi.org/simple \
+              "autoconf[optional]==$VERSION" \
+              "autoarray[optional]==$VERSION" \
+              "autofit[optional]==$VERSION" \
+              "autogalaxy[optional]==$VERSION" \
+              "autolens[optional]==$VERSION"; do
+          ((install_cnt=install_cnt+1))
+          if [[ $install_cnt -ge 30 ]]; then
+            echo "ERROR: Install failed after 30 attempts"
+            exit 1
+          fi
+          sleep 10
+        done
+        pip install matplotlib==3.6.0 pynufft==2025.1.1 numba
+        pushd workspace
+        python3 work/audit_skill_apis.py --write-baseline
+        git add wiki/core/api_audit_baseline.json
+        git commit -m "Release $VERSION: regenerate API audit baseline" || true
+        popd
     - name: Bump Colab URL tag refs
       if: "${{ github.event.inputs.skip_release != 'true' && matrix.workspace.bump_colab_urls == true }}"
       run: |

--- a/pre_build.sh
+++ b/pre_build.sh
@@ -99,6 +99,10 @@ run_workspace "HowToLens"                            "howtolens"    true   false
 run_workspace "HowToFit"                             "howtofit"     true   false  PyAutoFit
 run_workspace "autofit_workspace_developer"          ""             false  false  ""
 run_workspace "autolens_workspace_developer"         ""             false  false  ""
+# The AI assistant repo. No notebook generation or README pin; release.yml's
+# release_workspaces job stamps its workspace version and regenerates
+# wiki/core/api_audit_baseline.json against the released wheels.
+run_workspace "autolens_assistant"                   "autolens"     false  false  ""
 
 # Commit and push PyAutoBuild itself
 echo ""

--- a/verify_workspace_versions.sh
+++ b/verify_workspace_versions.sh
@@ -16,9 +16,9 @@
 # If both exist and disagree, the script fails — they must be kept in sync
 # by the release pipeline.
 #
-# Compares each of the 7 workspaces (3 main + 3 HowTo + euclid_pipeline)
-# against its installed library version, parsed as a YYYY.M.D.B 4-tuple of
-# ints. Exits 1 if any workspace.version > library.version.
+# Compares each of the 8 workspaces (3 main + 3 HowTo + euclid_pipeline +
+# autolens_assistant) against its installed library version, parsed as a
+# YYYY.M.D.B 4-tuple of ints. Exits 1 if any workspace.version > library.version.
 #
 # Workspace → library mapping mirrors the release_workspaces matrix in
 # .github/workflows/release.yml.
@@ -37,6 +37,7 @@ WORKSPACES=(
     "HowToGalaxy|autogalaxy"
     "HowToLens|autolens"
     "euclid_strong_lens_modeling_pipeline|autolens"
+    "autolens_assistant|autolens"
 )
 
 # Compare two YYYY.M.D.B versions. Echoes AHEAD / BEHIND / MATCH / BAD.


### PR DESCRIPTION
Closes #96. Companion PR: PyAutoLabs/autolens_assistant (adds the `version:` block this pipeline stamps).

## What

Registers `autolens_assistant` as a release-pipeline workspace and auto-refreshes its API version pin on each release — completing the Kernel2D/API-drift series (autolens_assistant #10 tooling+policy, #12 wiki cleanup, this = release automation).

| File | Change |
|---|---|
| `pre_build.sh` | `run_workspace "autolens_assistant" "autolens" false false ""` — black + commit/push; no notebook generation, no README pin. |
| `verify_workspace_versions.sh` | `WORKSPACES` entry `autolens_assistant\|autolens` (header 7 → 8). Blocks a release if the assistant's pinned version is ahead of installed. |
| `.github/workflows/release.yml` | `release_workspaces` matrix entry (`write_api_baseline: true`) + a gated **Regenerate API audit baseline** step: installs the released wheels, runs the assistant's own `work/audit_skill_apis.py --write-baseline`, commits `wiki/core/api_audit_baseline.json` alongside the version stamp. |

## Design (resolved from the issue's open questions)

- **Mechanism:** PyAutoBuild invokes the assistant's own `--write-baseline` — the assistant owns the hash format, so the two never diverge.
- **Where:** CI (`release.yml`), post-publish, against the released wheels — *not* `pre_build.sh`, which runs locally before PyPI publishes.
- **Version stamp:** reuses the existing "Write workspace version" step (writes `config/general.yaml` `version.workspace_version` + `version.txt`); the new step only adds the baseline regen.

## Verification

- `python -c yaml.safe_load` on `release.yml` → valid.
- `bash -n` on both shell scripts → clean.
- `verify_workspace_versions.sh` → all 8 workspaces (incl. `autolens_assistant`) report **ok**.
- ⚠️ The `release.yml` job path can't be exercised without a real release — YAML-validated + dry-reasoned only; the **next release validates end-to-end**. The new step is gated to `write_api_baseline == true`, so it cannot affect the other workspaces' release path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)