### PR TITLE
ci(autobuild): delegate watch/status/tick/fix to PyAutoPulse

### DIFF
--- a/bin/autobuild
+++ b/bin/autobuild
@@ -44,6 +44,11 @@ SUBCOMMAND_ORDER=(
   tag_and_merge
   "# Triage support"
   repro_command
+  "# Monitoring daemon (delegates to PyAutoPulse)"
+  watch
+  status
+  tick
+  fix
   "# Meta"
   help
 )
@@ -65,6 +70,10 @@ declare -A SHORT_DESC=(
   [create_analysis_issue]="Open a GitHub issue with the release report and assign Copilot"
   [tag_and_merge]="Commit and tag every library repo for a release"
   [repro_command]="Emit the shell command autobuild uses to run one script (for triage handoffs)"
+  [watch]="Start the PyAutoPulse monitoring daemon (Ctrl-C to stop)"
+  [status]="Print the latest PyAutoPulse state cache with green/yellow/red"
+  [tick]="Force one PyAutoPulse refresh cycle"
+  [fix]="Bundle context for a Pulse failure topic and emit a Claude invocation"
   [help]="List subcommands or show details for one"
 )
 
@@ -408,6 +417,109 @@ EOF
 }
 cmd_repro_command() {
   _python_in_autobuild repro_command.py "$@"
+}
+
+# ----- Monitoring daemon (delegates to PyAutoPulse) -----
+#
+# These four subcommands shim through to the standalone `pyauto-pulse`
+# binary installed from the sibling PyAutoLabs/PyAutoPulse repo. The
+# split is deliberate: PyAutoBuild produces releases; PyAutoPulse
+# monitors developer state continuously. Co-locating the CLI surface
+# (via these shims) without sharing Python code keeps both repos
+# independently releasable.
+#
+# If `pyauto-pulse` is not on PATH, the shim prints an install hint and
+# exits 127.
+
+_pulse_resolve() {
+  # Resolve a path/command for the pyauto-pulse binary. Try:
+  #   1. PATH (works if `pip install pyautopulse` made the entry point global)
+  #   2. The bin script in the sibling PyAutoPulse repo checkout
+  # Prints the resolved invocation on stdout, returns 0 on success.
+  if command -v pyauto-pulse >/dev/null 2>&1; then
+    printf 'pyauto-pulse'
+    return 0
+  fi
+  local pulse_bin="$HOME/Code/PyAutoLabs/PyAutoPulse/bin/pyauto-pulse"
+  if [[ -x "$pulse_bin" ]]; then
+    printf '%s' "$pulse_bin"
+    return 0
+  fi
+  cat >&2 <<EOF
+autobuild: pyauto-pulse is not installed and the sibling checkout was
+not found at $HOME/Code/PyAutoLabs/PyAutoPulse/.
+
+Clone + install with:
+  git clone https://github.com/PyAutoLabs/PyAutoPulse.git \$HOME/Code/PyAutoLabs/PyAutoPulse
+  pip install -e \$HOME/Code/PyAutoLabs/PyAutoPulse
+EOF
+  return 127
+}
+
+help_watch() {
+  cat <<'EOF'
+autobuild watch [interval_seconds]
+
+Shim → `pyauto-pulse watch`. Run the PyAutoPulse monitoring daemon in
+the foreground, refreshing the cached state every N seconds (default
+300s). Ctrl-C to stop.
+
+See `pyauto-pulse help watch` for full docs.
+EOF
+}
+cmd_watch() {
+  local pulse_bin
+  pulse_bin="$(_pulse_resolve)" || return $?
+  exec "$pulse_bin" watch "$@"
+}
+
+help_status() {
+  cat <<'EOF'
+autobuild status [--json] [--quiet] [--no-color]
+
+Shim → `pyauto-pulse status`. Print the most recent Pulse state cache
+with green/yellow/red colouring. Exits non-zero if no cache exists
+(run `autobuild tick` first).
+EOF
+}
+cmd_status() {
+  local pulse_bin
+  pulse_bin="$(_pulse_resolve)" || return $?
+  exec "$pulse_bin" status "$@"
+}
+
+help_tick() {
+  cat <<'EOF'
+autobuild tick
+
+Shim → `pyauto-pulse tick`. Force one PyAutoPulse refresh cycle: every
+check (repo state, CI status, open PRs, worktree drift, script
+timing) runs and the aggregated snapshot is written.
+EOF
+}
+cmd_tick() {
+  local pulse_bin
+  pulse_bin="$(_pulse_resolve)" || return $?
+  exec "$pulse_bin" tick "$@"
+}
+
+help_fix() {
+  cat <<'EOF'
+autobuild fix <topic> [args...]
+
+Shim → `pyauto-pulse fix`. Bundle context for a specific failing topic
+and emit a Claude Code invocation you can paste/run.
+
+Topics:
+  ci <repo>         the latest red CI run on that repo
+  drift             current worktree drift
+  timing <project>  script timing regressions for that project
+EOF
+}
+cmd_fix() {
+  local pulse_bin
+  pulse_bin="$(_pulse_resolve)" || return $?
+  exec "$pulse_bin" fix "$@"
 }
 
 # ----- Meta -----


### PR DESCRIPTION
## Summary

Adds four thin shim subcommands to the `autobuild` dispatcher that delegate to the new sibling repo [PyAutoLabs/PyAutoPulse](https://github.com/PyAutoLabs/PyAutoPulse) (a continuous-monitoring daemon for the PyAuto ecosystem):

```
autobuild watch    → pyauto-pulse watch       # start daemon
autobuild status   → pyauto-pulse status      # print cached state with g/y/r
autobuild tick     → pyauto-pulse tick        # one-shot refresh
autobuild fix ...  → pyauto-pulse fix ...     # emit Claude invocation for a topic
```

## Why a shim instead of co-located?

The two repos share **no Python code**. PyAutoBuild is "produce releases"; PyAutoPulse is "monitor developer state continuously." Bundling them would muddy PyAutoBuild's elevator pitch, force the daemon's rapid iteration into PyAutoBuild's release-paced history, and risk daemon experimentation breaking release tooling. Separate repos with a shared CLI surface (this PR) gets the unified UX without the coupling.

## Resolution order

The shim tries these in order:
1. `command -v pyauto-pulse` (works if `pip install -e PyAutoPulse` made the entrypoint global)
2. `$HOME/Code/PyAutoLabs/PyAutoPulse/bin/pyauto-pulse` (sibling checkout, no install needed)
3. otherwise: print install hint, exit 127

## Test plan

- [x] `bash bin/autobuild help` shows the new subcommands under "Monitoring daemon"
- [x] `bash bin/autobuild help watch` renders the shim docstring
- [x] `bash bin/autobuild status` delegates correctly to a sibling checkout when `pyauto-pulse` is not on PATH
- [x] 78/78 existing PyAutoBuild tests still pass — no Python changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)