### PR TITLE
ci(release): explicit jax install in every install block as backstop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,12 @@ jobs:
               echo "  Install attempt $install_cnt failed, retrying in 10s..."
               sleep 10
             done
+            # Belt-and-braces: the [optional] → [jax] extras chain should
+            # pull JAX, but installs from test.pypi.org with mixed indexes
+            # have historically silently dropped the dep. Force the install
+            # so jax_likelihood_functions / jax_grad / jax_substructure
+            # scripts can't fail in 0.1s with ModuleNotFoundError.
+            pip install "jax>=0.7,<0.11" "jaxlib>=0.7,<0.11"
         - name: Tests
           run: |
             pushd "${{ matrix.project.path }}"
@@ -226,6 +232,9 @@ jobs:
             sleep 10
           done
           pip install matplotlib==3.6.0 pynufft==2025.1.1 numba
+          # Belt-and-braces JAX install — the [optional] → [jax] chain
+          # occasionally silently drops jax from test.pypi resolution.
+          pip install "jax>=0.7,<0.11" "jaxlib>=0.7,<0.11"
       - name: Run smoke tests
         run: |
           cd ${{ matrix.workspace.path }}
@@ -478,6 +487,12 @@ jobs:
           pip install matplotlib==3.6.0
           pip install pynufft==2025.1.1
           pip install numba
+          # JAX is required by every jax_likelihood_functions / jax_grad /
+          # jax_substructure script. The bare `autoconf + project` install
+          # below does NOT pull [optional] extras, so JAX would otherwise
+          # be missing and every such script would fail in 0.1s with
+          # ModuleNotFoundError.
+          pip install "jax>=0.7,<0.11" "jaxlib>=0.7,<0.11"
     - name: Install project
       if: "${{ github.event.inputs.skip_scripts != 'true' }}"
       run: |
@@ -588,6 +603,9 @@ jobs:
         pip install matplotlib==3.6.0
         pip install pynufft==2025.1.1
         pip install numba
+        # JAX is required by every jax_likelihood_functions / jax_grad /
+        # jax_substructure notebook. Same reason as run_scripts above.
+        pip install "jax>=0.7,<0.11" "jaxlib>=0.7,<0.11"
     - name: Install project
       if: "${{ github.event.inputs.skip_notebooks != 'true' && !endsWith(matrix.project.name, '_test') }}"
       run: |
@@ -939,6 +957,8 @@ jobs:
           sleep 10
         done
         pip install matplotlib==3.6.0 pynufft==2025.1.1 numba
+        # Belt-and-braces JAX install (same reason as the install steps above).
+        pip install "jax>=0.7,<0.11" "jaxlib>=0.7,<0.11"
         pushd workspace
         python3 work/audit_skill_apis.py --write-baseline
         git add wiki/core/api_audit_baseline.json


### PR DESCRIPTION
## Summary

- Adds `pip install "jax>=0.7,<0.11" "jaxlib>=0.7,<0.11"` immediately after every `until ... pip install autoconf[optional]==$VERSION ...` block in `release.yml` (5 sites).
- Belt-and-braces defence against the failure mode that took down today's 06:08 scheduled release: pip's resolver silently downgraded `jax` to `0.4.28` (then dropped it entirely), so every run_scripts job failed in ~0.1s with `ModuleNotFoundError: No module named 'jax'`.
- The KEY FIX is the `run_scripts` job's "Install optional requirements" step (line ~495) — that step previously installed NO `[optional]` extras at all, so JAX was never installed there regardless of resolver behaviour.
- Paired with PyAutoFit #1306 which removes the root-cause `anesthetic==2.8.14` → `numpy<2` constraint chain.

## Sites updated

| Job | Line | Context |
|---|---|---|
| `run_unit_tests` | 164 | until-loop |
| testpypi smoke install | 237 | TestPyPI install for smoke tests |
| `run_scripts` optional requirements | 495 | **KEY FIX — no [optional] extras here before** |
| `run_notebooks` optional requirements | 608 | notebooks job optional requirements |
| Regenerate API audit baseline | 961 | TestPyPI install for audit regen |

## Test plan

- [ ] CI on this PR (workflow-syntax-only sanity check; the real test is the next `pre_build` dispatch)
- [ ] Merge after PyAutoFit #1306 is in
- [ ] Run `autobuild pre_build 2` → release.yml dispatch → confirm run_scripts jobs no longer fail in 0.1s with JAX import error

🤖 Generated with [Claude Code](https://claude.com/claude-code)