### PR TITLE
ci(release): bypass workspace version check in run_scripts/run_notebooks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -407,6 +407,15 @@ jobs:
         python-version: [3.12]
         project:
             ${{ fromJSON(needs.find_scripts.outputs.matrix) }}
+    env:
+      # release_workspaces (which writes the bumped workspace_version pin
+      # into config/general.yaml on each workspace main) depends on
+      # run_scripts passing. So on the first script run after a release,
+      # the workspace pin is one version behind the just-published library
+      # and autoconf.workspace.check_version raises
+      # WorkspaceVersionMismatchError, failing every script in 1s.
+      # Mirror the bypass run_smoke_tests already uses for the same reason.
+      PYAUTO_SKIP_WORKSPACE_VERSION_CHECK: "1"
     steps:
     - name: Configure
       if: "${{ github.event.inputs.skip_scripts != 'true' }}"
@@ -531,6 +540,11 @@ jobs:
         python-version: [3.12]
         project:
             ${{ fromJSON(needs.find_scripts.outputs.matrix) }}
+    env:
+      # Same reason as run_scripts above — release_workspaces writes the
+      # bumped pin only after this job passes. Without the bypass, every
+      # notebook crashes with WorkspaceVersionMismatchError.
+      PYAUTO_SKIP_WORKSPACE_VERSION_CHECK: "1"
     steps:
     - name: Configure
       if: "${{ github.event.inputs.skip_notebooks != 'true' && !endsWith(matrix.project.name, '_test') }}"


### PR DESCRIPTION
## Summary

- Adds \`PYAUTO_SKIP_WORKSPACE_VERSION_CHECK: "1"\` to the env block on \`run_scripts\` and \`run_notebooks\` jobs in \`release.yml\`.
- Mirrors the existing bypass on \`run_smoke_tests\`, fixing the same chicken-and-egg pattern.

## Repro (2026.5.29.2 release run)

\`release_workspaces\` writes the bumped \`workspace_version\` pin into each workspace's \`config/general.yaml\` on \`main\` — but it depends on \`run_scripts + run_notebooks\` passing. So on every release dispatch:

1. CI publishes library to TestPyPI at the new version (\`2026.5.29.2\`).
2. CI installs that version + checks out workspace \`main\`, which still pins the LAST released version (\`2026.5.21.1\`).
3. Every script in \`run_scripts\` and \`run_notebooks\` crashes in ~1s with \`WorkspaceVersionMismatchError\`.
4. \`release_workspaces\` never runs → pin stays behind → next release hits exactly the same wall.

This explains why the last 4 \`release.yml\` runs have all failed in run_scripts immediately after install — the workspace pin has been frozen at \`2026.5.21.1\` since May 21.

## Fix

\`\`\`yaml
run_scripts:
  ...
  env:
    PYAUTO_SKIP_WORKSPACE_VERSION_CHECK: "1"

run_notebooks:
  ...
  env:
    PYAUTO_SKIP_WORKSPACE_VERSION_CHECK: "1"
\`\`\`

\`run_smoke_tests\` already has this for the same reason.

## Paired with

- PyAutoGalaxy companion PR
- PyAutoLens companion PR

(Cluster 1 — pytree dup — would still block \`run_smoke_tests autogalaxy_workspace\` even after this PR lands.)

## Test plan

- [ ] CI on this PR (workflow syntax)
- [ ] Merge after the autogalaxy + autolens PRs land
- [ ] Re-dispatch \`autobuild pre_build\` and confirm \`run_scripts\` jobs no longer fail in 1s

🤖 Generated with [Claude Code](https://claude.com/claude-code)