### PR TITLE
Update pyauto-pulse resolve hint to no-pip PYTHONPATH+PATH setup

### DIFF
--- a/bin/autobuild
+++ b/bin/autobuild
@@ -446,12 +446,16 @@ _pulse_resolve() {
     return 0
   fi
   cat >&2 <<EOF
-autobuild: pyauto-pulse is not installed and the sibling checkout was
-not found at $HOME/Code/PyAutoLabs/PyAutoPulse/.
+autobuild: pyauto-pulse was not found on PATH or at the sibling checkout
+$HOME/Code/PyAutoLabs/PyAutoPulse/.
 
-Clone + install with:
+PyAutoPulse is not pip-installed — like the other PyAuto repos it runs from
+its checkout via PYTHONPATH + PATH in ~/.bashrc. Set it up with:
   git clone https://github.com/PyAutoLabs/PyAutoPulse.git \$HOME/Code/PyAutoLabs/PyAutoPulse
-  pip install -e \$HOME/Code/PyAutoLabs/PyAutoPulse
+  # add to ~/.bashrc:
+  #   export PATH="\$HOME/Code/PyAutoLabs/PyAutoPulse/bin:\$PATH"
+  #   export PYTHONPATH="\$PYTHONPATH:\$HOME/Code/PyAutoLabs/PyAutoPulse"
+  source ~/.bashrc
 EOF
   return 127
 }


### PR DESCRIPTION
PyAutoPulse now runs from its checkout (`PYTHONPATH` + `PATH` in `~/.bashrc`)
like the other PyAuto repos, not via `pip install -e`. This updates the
`_pulse_resolve` fallback hint in `bin/autobuild` so the `watch/status/tick/
fix` shims point users at the correct setup when `pyauto-pulse` isn't found.

One-line behaviour unchanged otherwise — the checkout-bin fallback already
resolved correctly; only the error hint text changes.

Pairs with PyAutoLabs/PyAutoPulse#1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)