### PR TITLE
ci: reusable navigator_check workflow + catalogue entrypoints

### DIFF
--- a/.github/workflows/navigator_check.yml
+++ b/.github/workflows/navigator_check.yml
@@ -1,0 +1,97 @@
+name: Navigator Check (reusable)
+
+# Reusable workspace-catalogue check, called by each workspace's thin
+# navigator_check.yml. The caller passes its generator project name; everything
+# else (the check_navigator / regenerate_navigator entrypoints, the staleness
+# logic) lives here so the three workspaces share one copy.
+#
+# Both jobs check out the *caller* workspace (default checkout) plus this repo
+# (PyAutoBuild), because the navigator entrypoints now live in PyAutoBuild.
+
+on:
+  workflow_call:
+    inputs:
+      project:
+        description: Generator project name (autolens / autogalaxy / autofit).
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  paths:
+    name: Navigator paths + banner lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout workspace
+        uses: actions/checkout@v4
+        with:
+          path: workspace
+      - name: Checkout PyAutoBuild
+        uses: actions/checkout@v4
+        with:
+          repository: PyAutoLabs/PyAutoBuild
+          path: PyAutoBuild
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: pip install --quiet pyyaml
+      - name: Run navigator checker (paths hard, banners fail)
+        run: python PyAutoBuild/autobuild/check_navigator.py --root workspace --banners=fail
+
+  staleness:
+    name: Catalogue staleness
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout workspace
+        uses: actions/checkout@v4
+        with:
+          path: workspace
+      - name: Checkout PyAutoBuild
+        uses: actions/checkout@v4
+        with:
+          repository: PyAutoLabs/PyAutoBuild
+          path: PyAutoBuild
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Extract branch name
+        id: extract_branch
+        shell: bash
+        run: |
+          cd workspace
+          echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> "$GITHUB_OUTPUT"
+      - name: Match PyAutoBuild branch
+        shell: bash
+        run: |
+          BRANCH="${{ steps.extract_branch.outputs.branch }}"
+          pushd PyAutoBuild
+          if [[ -n "$(git ls-remote --heads origin "$BRANCH")" ]]; then
+            echo "Branch $BRANCH exists in PyAutoBuild — checking out"
+            git fetch origin "$BRANCH"
+            git checkout "$BRANCH"
+          else
+            echo "Branch $BRANCH not in PyAutoBuild — staying on default branch"
+          fi
+          popd
+      - name: Install dependencies
+        run: pip install --quiet pyyaml
+      - name: Regenerate catalogue (Phase 2 only — no notebook rebuild)
+        env:
+          NAVIGATOR_PROJECT: ${{ inputs.project }}
+        run: |
+          cd workspace
+          python ../PyAutoBuild/autobuild/regenerate_navigator.py "$NAVIGATOR_PROJECT"
+      - name: Fail if catalogue drifted from scripts
+        shell: bash
+        run: |
+          cd workspace
+          if ! git diff --exit-code llms-full.txt workspace_index.json; then
+            echo "::error::llms-full.txt / workspace_index.json are stale."
+            echo "Regenerate with 'generate.py ${{ inputs.project }}' and commit the result."
+            exit 1
+          fi

--- a/autobuild/check_navigator.py
+++ b/autobuild/check_navigator.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""
+Navigator / workspace catalogue checker.
+
+Two independent checks, runnable locally or in CI:
+
+  (a) Path existence (HARD FAIL)
+      Scan the workspace's navigator / instruction files for repo-relative
+      ``scripts/...`` and ``notebooks/...`` references and confirm each resolves
+      on disk. A reference may be a literal path (must exist) or a glob
+      containing ``*`` (must match at least one file). ``output/...`` and
+      ``dataset/...`` references are ignored (runtime / data, not example code).
+      In ``workspace_index.json`` only the authoritative ``path`` / ``notebook``
+      fields are validated; ``cross_refs`` are best-effort docstring references
+      and are not required to resolve.
+
+  (b) Banner-comment lint (warn or fail, see ``--banners``)
+      Scan ``scripts/**/*.py`` for banner-style separator comments — a comment
+      line that is ``#`` followed only by a run (>= 4) of ``-``, ``=``, ``#`` or
+      ``*``. The workspace style is ``\"\"\"__Section__\"\"\"`` docstrings, not
+      ``# -----`` banners. The ``===`` underline beneath a docstring title is not
+      a ``#`` comment and is never flagged.
+
+This script is intentionally repo-agnostic: it hardcodes no repository name and
+operates on the workspace given by ``--root`` (default: the current working
+directory), so the autolens / galaxy / fit workspaces all share this one copy.
+It lives in PyAutoBuild and is invoked by the reusable ``navigator_check``
+workflow; run it locally against a workspace checkout with::
+
+    python /path/to/PyAutoBuild/autobuild/check_navigator.py --root /path/to/workspace
+    python /path/to/PyAutoBuild/autobuild/check_navigator.py --root /path/to/workspace --banners=warn
+
+An optional ignore file (default ``.navigator_check_ignore``) lists paths or
+globs (one per line, ``#`` comments allowed) that are exempt from BOTH checks.
+"""
+
+import argparse
+import fnmatch
+import re
+import sys
+from pathlib import Path
+
+# Files scanned for path references. ``scripts/**/README.md`` is expanded at
+# runtime. Missing files are simply skipped (e.g. a workspace without one of
+# these), so the same list ports across workspaces.
+REFERENCE_FILES = [
+    "AGENTS.md",
+    "CLAUDE.md",
+    ".github/copilot-instructions.md",
+    "llms.txt",
+    "llms-full.txt",
+    "workspace_index.json",
+]
+
+# Path tokens we care about: example code / notebooks under the workspace. The
+# negative lookbehind anchors the token at a path boundary so a longer path such
+# as ".github/scripts/run_smoke.py" is NOT matched as "scripts/run_smoke.py".
+_PATH_TOKEN_RE = re.compile(
+    r"(?<![A-Za-z0-9_./-])(?:scripts|notebooks)/[A-Za-z0-9_./*-]+"
+)
+
+# In workspace_index.json only the authoritative "path" / "notebook" fields are
+# checked. "cross_refs" (and prose in "summary") are best-effort docstring
+# references that may legitimately not resolve, so they are not validated here.
+_JSON_AUTHORITATIVE_KEY_RE = re.compile(r'^\s*"(?:path|notebook)"\s*:')
+
+# A banner separator comment: '#', optional whitespace, then ONLY a run (>=4) of
+# the separator characters. Does not match '# ----- Section -----' (has text) or
+# the docstring '===' underline (not a '#' comment).
+_BANNER_RE = re.compile(r"^\s*#\s*[-=#*]{4,}\s*$")
+
+DEFAULT_IGNORE_FILE = ".navigator_check_ignore"
+
+
+def load_ignore(root: Path, ignore_file: str):
+    """Load ignore patterns (paths / globs). Returns a list of POSIX strings."""
+    path = root / ignore_file
+    patterns = []
+    if path.exists():
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                patterns.append(line)
+    return patterns
+
+
+def is_ignored(rel_path: str, patterns) -> bool:
+    """True if ``rel_path`` matches an ignore pattern (literal or glob)."""
+    return any(
+        rel_path == pat or fnmatch.fnmatch(rel_path, pat) for pat in patterns
+    )
+
+
+def reference_files(root: Path):
+    """Yield the existing reference files, including scripts/**/README.md."""
+    for name in REFERENCE_FILES:
+        candidate = root / name
+        if candidate.exists():
+            yield candidate
+    for readme in sorted((root / "scripts").rglob("README.md")):
+        yield readme
+
+
+def extract_path_tokens(text: str, json_authoritative_only: bool = False):
+    """
+    Yield (line_number, token) for every scripts/.. or notebooks/.. token in the
+    text. Works uniformly for markdown links and inline-code spans, since all we
+    need is the token substring on its line.
+
+    When ``json_authoritative_only`` is set (for workspace_index.json), only
+    lines holding the authoritative ``"path"`` / ``"notebook"`` keys are scanned,
+    so best-effort ``cross_refs`` and prose ``summary`` values are skipped.
+    """
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if json_authoritative_only and not _JSON_AUTHORITATIVE_KEY_RE.match(line):
+            continue
+        for match in _PATH_TOKEN_RE.findall(line):
+            # Strip trailing punctuation that commonly abuts a token in prose
+            # (e.g. "see scripts/foo.py." or a token closing a code span).
+            token = match.rstrip(".,;:)`\"'")
+            yield lineno, token
+
+
+def check_paths(root: Path, ignore_patterns):
+    """Return a list of (file, line, token) misses. Empty list == all good."""
+    misses = []
+    for ref in reference_files(root):
+        rel_ref = ref.relative_to(root).as_posix()
+        try:
+            text = ref.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            print(f"WARNING: could not read {rel_ref}: {exc}", file=sys.stderr)
+            continue
+        json_only = ref.suffix == ".json"
+        for lineno, token in extract_path_tokens(text, json_only):
+            if is_ignored(token, ignore_patterns):
+                continue
+            if "*" in token:
+                if not any(root.glob(token)):
+                    misses.append((rel_ref, lineno, token))
+            else:
+                if not (root / token).exists():
+                    misses.append((rel_ref, lineno, token))
+    return misses
+
+
+def check_banners(root: Path, ignore_patterns):
+    """Return a list of (file, line) banner-comment hits."""
+    hits = []
+    for script in sorted((root / "scripts").rglob("*.py")):
+        rel = script.relative_to(root).as_posix()
+        if is_ignored(rel, ignore_patterns):
+            continue
+        try:
+            lines = script.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeDecodeError) as exc:
+            print(f"WARNING: could not read {rel}: {exc}", file=sys.stderr)
+            continue
+        for lineno, line in enumerate(lines, start=1):
+            if _BANNER_RE.match(line):
+                hits.append((rel, lineno))
+    return hits
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="Workspace root to check (default: current directory).",
+    )
+    parser.add_argument(
+        "--banners",
+        choices=["warn", "fail"],
+        default="fail",
+        help="Banner-comment lint mode: 'fail' (nonzero exit) or 'warn'.",
+    )
+    parser.add_argument(
+        "--ignore-file",
+        default=DEFAULT_IGNORE_FILE,
+        help=f"Ignore file of paths/globs (default: {DEFAULT_IGNORE_FILE}).",
+    )
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    ignore_patterns = load_ignore(root, args.ignore_file)
+
+    # (a) Path existence — always a hard failure.
+    path_misses = check_paths(root, ignore_patterns)
+    if path_misses:
+        print(f"Path check: {len(path_misses)} missing reference(s):")
+        for ref, lineno, token in path_misses:
+            print(f"  {ref}:{lineno} -> missing path: {token}")
+    else:
+        print("Path check: OK — every scripts/ and notebooks/ reference resolves.")
+
+    # (b) Banner lint — warn or fail.
+    banner_hits = check_banners(root, ignore_patterns)
+    if banner_hits:
+        print(f"Banner lint: {len(banner_hits)} banner-style comment(s):")
+        for ref, lineno in banner_hits:
+            print(f"  {ref}:{lineno}")
+        print(
+            "  Use triple-quoted \"\"\"__Section__\"\"\" docstrings, not # ----- banners."
+        )
+    else:
+        print("Banner lint: OK — no banner-style comments found.")
+
+    failed = bool(path_misses) or (args.banners == "fail" and bool(banner_hits))
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/autobuild/regenerate_navigator.py
+++ b/autobuild/regenerate_navigator.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""
+Regenerate the workspace catalogue (Phase 2 only — no notebook rebuild).
+
+This is the lightweight entrypoint the reusable ``navigator_check`` staleness
+job uses, and the one a maintainer runs locally to refresh a catalogue. It calls
+``navigator.write_catalogue`` for the workspace checkout in the *current working
+directory*, producing ``llms-full.txt`` and ``workspace_index.json`` *without*
+running the full notebook generation and *without* needing the science stack
+(only ``pyyaml``).
+
+It lives beside ``navigator.py`` in PyAutoBuild, so it no longer needs the
+``PYAUTOBUILD_DIR`` path plumbing the old per-workspace shim used — it imports
+``navigator`` from its own directory. The generator project is taken from the
+first CLI argument, falling back to the ``NAVIGATOR_PROJECT`` environment
+variable, then ``autolens``.
+
+Run from the workspace root (CWD is the workspace to catalogue, not this
+package)::
+
+    python /path/to/PyAutoBuild/autobuild/regenerate_navigator.py autogalaxy
+    NAVIGATOR_PROJECT=autofit python /path/to/PyAutoBuild/autobuild/regenerate_navigator.py
+"""
+
+import os
+import sys
+from pathlib import Path
+
+
+def main():
+    project = (
+        sys.argv[1]
+        if len(sys.argv) > 1
+        else os.environ.get("NAVIGATOR_PROJECT", "autolens")
+    )
+
+    # navigator.py is a sibling of this file; put its directory on the path so
+    # ``import navigator`` resolves regardless of the current working directory
+    # (CWD is the workspace target passed to write_catalogue, not this package).
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+    # navigator imports generate.py lazily, whose module-level argparse expects a
+    # project positional; supply it via argv so the import resolves cleanly.
+    sys.argv = ["generate.py", project]
+
+    import navigator
+
+    navigator.write_catalogue(Path.cwd(), project)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

The three workspaces (autolens/autogalaxy/autofit) each carried a **byte-identical** pair of navigator scripts (`check_navigator.py`, `regenerate_navigator.py`) plus a `navigator_check.yml` that differed by exactly one line (the `PROJECT` name). This hosts that logic here, once, so each workspace becomes a thin caller.

- `autobuild/check_navigator.py` — path/banner lint, moved verbatim (already repo-agnostic via `--root`).
- `autobuild/regenerate_navigator.py` — Phase-2 catalogue regen; imports the sibling `navigator.py` directly (drops the per-workspace `PYAUTOBUILD_DIR` plumbing); project via argv / `NAVIGATOR_PROJECT` env.
- `.github/workflows/navigator_check.yml` — reusable (`on: workflow_call`) with a `project` input; reproduces the `paths` + `staleness` jobs, checking out the **caller** workspace plus this repo.

## Verification

Locally ran the moved entrypoints against all three workspace checkouts: `check_navigator` passes (paths + banners, exit 0) and `regenerate_navigator` produces **zero drift** vs the committed `llms-full.txt` / `workspace_index.json` for all three projects.

The reusable-workflow wiring is exercised end-to-end by the workspace PRs that follow this merge (they reference `...navigator_check.yml@main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)