### PR TITLE
feat: add HowTo lecture-repo titles to navigator catalogue

### DIFF
--- a/autobuild/navigator.py
+++ b/autobuild/navigator.py
@@ -65,6 +65,9 @@ WORKSPACE_TITLES = {
     "autocti": "PyAutoCTI Workspace",
     "autogalaxy": "PyAutoGalaxy Workspace",
     "autolens": "PyAutoLens Workspace",
+    "howtolens": "HowToLens Lectures",
+    "howtogalaxy": "HowToGalaxy Lectures",
+    "howtofit": "HowToFit Lectures",
 }
 
 


### PR DESCRIPTION
Register `howtolens` / `howtogalaxy` / `howtofit` in `WORKSPACE_TITLES` (`autobuild/navigator.py`) so each HowTo repo's generated `llms-full.txt` header reads e.g. **HowToLens Lectures** instead of the generic `howtolens workspace` fallback.

Purely additive — different keys, so existing workspace catalogues are byte-unchanged. Prerequisite for the three HowTo repos to ship the generated catalogue layer (follow-up PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)