### PR TITLE
Docs: canonical Build/Pulse/Agent boundary (Stage 5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# PyAutoBuild — Agent Guidance
+
+PyAutoBuild is the **executor** of the PyAuto release ecosystem: packaging,
+tagging, notebook generation, and PyPI publication via `release.yml`. It runs no
+release-readiness checks of its own — that is PyAutoPulse's job.
+
+## The boundary (one description, mirrored in all three repos)
+
+- **PyAutoPulse — the health authority.** All health/readiness logic lives here:
+  version drift, install-path, URL hygiene, CI/worktree/timing monitoring.
+  `pyauto-pulse readiness` is the **authoritative** green/yellow/red verdict —
+  the single "is it safe to release?" gate. Pulse is an observer: it reads and
+  emits verdicts; it never writes into other repos and never triggers Build.
+- **PyAutoBuild — the executor.** Packaging, tagging, notebook generation, and
+  PyPI publication via `release.yml`. Build runs **no** readiness checks of its
+  own and never re-derives a gate decision; it just executes.
+- **PyAutoAgent — the brain.** Hosts the agents that connect the two. It owns no
+  checks and no release steps; it gates on Pulse and delegates execution to
+  Build.
+
+## The call chain (always this order)
+
+```
+Agent  →  Pulse (gate)  →  Build (execute)
+```
+
+The agent asks `pyauto-pulse readiness --json`; only on a **green** verdict does
+it trigger Build's release. Pulse never triggers Build; Build never re-derives a
+gate decision the agent already made.
+
+## What moved out of Build
+
+Release-readiness checking is no longer Build's job. The version-skew gate, the
+deep `verify_install` suite, and URL hygiene all live in PyAutoPulse now;
+`autobuild verify_install` / `autobuild url_check` / `autobuild watch|status|
+tick|fix` are thin shims that delegate to `pyauto-pulse`. Build keeps only the
+executor primitives (`pre_build`, `generate`, `run*`, `tag_and_merge`,
+`bump_colab_urls`, `release.yml`).
+
+See [`CLAUDE.md`](CLAUDE.md) for the build pipeline, workspace folder structure,
+config files, and `release.yml` details.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Project Does
 
-PyAutoBuild is a CI/CD build server for the PyAuto software family (PyAutoConf, PyAutoFit, PyAutoArray, PyAutoGalaxy, PyAutoLens). It automates:
+PyAutoBuild is the **executor** of the PyAuto release ecosystem (PyAutoConf, PyAutoFit, PyAutoArray, PyAutoGalaxy, PyAutoLens) — it runs **no** release-readiness checks of its own (that is PyAutoPulse's job; see [`AGENTS.md`](AGENTS.md) for the canonical Build/Pulse/Agent boundary and the `Agent → Pulse → Build` call chain). It automates:
 1. Building and releasing packages to TestPyPI, then PyPI
 2. Running workspace Python scripts (integration tests)
 3. Converting Python scripts to Jupyter notebooks and executing them
 4. Committing generated notebooks to workspace `main` branches and tagging each workspace with a version matching the released library
 
-The pipeline is triggered via GitHub Actions (`release.yml`) and is manually dispatched with configurable options.
+The pipeline is triggered via GitHub Actions (`release.yml`) and is manually dispatched with configurable options. Release-readiness gating happens upstream: the PyAutoAgent release agent calls `pyauto-pulse readiness` and only dispatches `release.yml` on a green verdict.
 
 ## Bash CLI
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PyAutoBuild: PyAuto Build Server
 
+PyAutoBuild is the **executor** of the PyAuto release ecosystem — it builds, tests and deploys, but runs no release-readiness checks (those belong to [PyAutoPulse](https://github.com/PyAutoLabs/PyAutoPulse); the [PyAutoAgent](https://github.com/PyAutoLabs/PyAutoAgent) release agent gates on `pyauto-pulse readiness` before dispatching a release). See `AGENTS.md` for the boundary.
+
 This project performs automatic building, testing and deployment of projects in the PyAuto software family:
 
 - [PyAutoConf](https://github.com/PyAutoLabs/PyAutoConf)


### PR DESCRIPTION
Final docs pass of the Build/Pulse/Agent separation. Adds an `AGENTS.md` carrying the **byte-identical** boundary + `Agent → Pulse → Build` call-chain block shared across PyAutoPulse, PyAutoBuild and PyAutoAgent, and reframes this repo's CLAUDE.md/README to the post-redesign roles. (PyAutoPulse PR also fixes the stale url_check_live.py footer.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)