### PR TITLE
Add a release-execution skills root (pre_build)

### DIFF
--- a/skills/pre_build/pre_build.md
+++ b/skills/pre_build/pre_build.md
@@ -1,0 +1,80 @@
+# Pre-Build: Format, Generate, Push, Dispatch
+
+Prepare all workspace repositories for a release build, then dispatch the GitHub Actions release workflow. This skill is a thin wrapper around `PyAutoBuild/bin/autobuild pre_build`, mirroring the pattern used by `/verify_install`.
+
+A **PyAutoBuild (Hands)** skill — Build is the release/packaging executor, and
+this is a **release-execution** entry point (format → generate → push →
+dispatch). It is the one skill class PyAutoBuild's `skills/` root hosts; Build
+owns **no** dev-workflow skills (`ship_*` live in PyAutoBrain and only *call*
+this release step). Readiness is gated upstream by Heart before a release is
+dispatched.
+
+## Steps
+
+### 1. Validate environment
+
+Check that all required repositories exist under the workspace root:
+- `autofit_workspace`
+- `autogalaxy_workspace`
+- `autolens_workspace`
+- `autofit_workspace_test`
+- `autogalaxy_workspace_test`
+- `autolens_workspace_test`
+- `euclid_strong_lens_modeling_pipeline`
+- `HowToGalaxy`
+- `HowToLens`
+- `HowToFit`
+- `PyAutoBuild`
+
+For each, verify:
+```bash
+git -C <repo> branch --show-current
+git -C <repo> status --short
+```
+
+All workspaces must be on `main`. If any are on a feature branch or have uncommitted changes, **stop and warn the user** — the pre-build expects clean `main` branches.
+
+Then ask the user for the minor version number (default: 1).
+
+### 2. Run `autobuild pre_build`
+
+Invoke the bash entry point directly:
+
+```bash
+bash $HOME/Code/PyAutoLabs/PyAutoBuild/bin/autobuild pre_build <minor_version>
+```
+
+The script handles every mechanical step of the pre-build flow:
+
+1. Ensures the canonical `pending-release` label exists on each release-window repo.
+2. For every workspace, runs `black .`, bumps the README version pin (`<Package> vYYYY.M.D.<minor>`) where applicable, runs `generate.py` for projects with a notebook target, and stages only the safe directories (`config/`, `notebooks/`, `scripts/`, `dataset/`, plus `slam_pipeline/` for `autolens_workspace`).
+3. Commits and pushes each workspace (skipping if no changes are staged).
+4. Commits and pushes PyAutoBuild itself.
+5. Runs `verify_workspace_versions.sh` to block release if any workspace `version.txt` is ahead of its installed library.
+6. Dispatches `gh workflow run release.yml --repo PyAutoLabs/PyAutoBuild --field minor_version=<N>`.
+
+If the script exits non-zero, surface the failure to the user verbatim and stop. Do not attempt to retry or repair — the script's preconditions (`set -e`) ensure that any non-zero exit reflects a real problem (lint failure, push rejected, workflow dispatch error).
+
+### 3. Summary
+
+When the script completes successfully, fetch and display the dispatched run URL:
+
+```bash
+gh run list --workflow=release.yml --repo PyAutoLabs/PyAutoBuild --limit 1 --json url --jq '.[0].url'
+```
+
+Then display:
+```
+Pre-Build Complete
+==================
+Minor version: <N>
+Workflow dispatched: <URL>
+
+The release workflow is now running. Use /review_release tomorrow
+to assess the results.
+```
+
+## Notes
+
+- The same operation is callable from the shell as `autobuild pre_build <minor>` (or `autobuild-help pre_build` for documentation). Use this skill when you want the Claude validation + summary wrapper; use the bash CLI when you just want to fire off the build.
+- README version-bump is now handled inside `pre_build.sh` (it used to live only in this skill).

--- a/skills/pre_build/pre_build.md
+++ b/skills/pre_build/pre_build.md
@@ -50,8 +50,12 @@ The script handles every mechanical step of the pre-build flow:
 2. For every workspace, runs `black .`, bumps the README version pin (`<Package> vYYYY.M.D.<minor>`) where applicable, runs `generate.py` for projects with a notebook target, and stages only the safe directories (`config/`, `notebooks/`, `scripts/`, `dataset/`, plus `slam_pipeline/` for `autolens_workspace`).
 3. Commits and pushes each workspace (skipping if no changes are staged).
 4. Commits and pushes PyAutoBuild itself.
-5. Runs `verify_workspace_versions.sh` to block release if any workspace `version.txt` is ahead of its installed library.
-6. Dispatches `gh workflow run release.yml --repo PyAutoLabs/PyAutoBuild --field minor_version=<N>`.
+5. Dispatches `gh workflow run release.yml --repo PyAutoLabs/PyAutoBuild --field minor_version=<N>`.
+
+Release-readiness — including the version-skew check that used to run here
+(`verify_workspace_versions.sh`) — is gated **upstream by PyAutoHeart**
+(`pyauto-heart readiness`) before `pre_build` is invoked, not by this step. Build
+is a pure executor.
 
 If the script exits non-zero, surface the failure to the user verbatim and stop. Do not attempt to retry or repair — the script's preconditions (`set -e`) ensure that any non-zero exit reflects a real problem (lint failure, push rejected, workflow dispatch error).
 


### PR DESCRIPTION
## Summary

Part of the 6-repo skill re-home/redesign. **Lead PR: PyAutoLabs/PyAutoBrain#5.**

PyAutoBuild gains a `skills/` root for its own **release-execution** skills, and `pre_build` moves here from admin_jammy.

`pre_build` (format → generate notebooks → push → dispatch `release.yml`) is a release/packaging operation — exactly what Build owns. This root is for **release-execution skills only**; Build still owns **no dev-workflow skills** (`ship_*` live in PyAutoBrain and only *call* this release step, with readiness gated upstream by Heart).

This intentionally revisits the earlier "Build gets no skills root" stance: that rule was about *dev-workflow* skills, and `pre_build` is release execution, so it belongs with Hands.

## Changes

- `skills/pre_build/pre_build.md` — moved from admin_jammy (command name `/pre_build` preserved); organ-boundary note added.

Discovery is wired up in the companion admin_jammy PR (`install.sh` + the line-count guard add `PyAutoBuild/skills/` as a root).

## Companion PRs (branch `claude/pyauto-skills-modernize-l29hxr`)

- Lead: PyAutoLabs/PyAutoBrain#5
- Jammy2211/admin_jammy#26 · PyAutoLabs/PyAutoMind#27 · PyAutoLabs/PyAutoHeart#22 · PyAutoLabs/autolens_profiling#51

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012v2ZYN4RCib1252BEWBb4t)_