### PR TITLE
PyAutoBuild: TestPyPI rehearsal mode + dispatch-surface cleanup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,10 @@ on:
         description: 'Update notebook visualisations'
         required: false
         default: 'false'
+      rehearsal:
+        description: 'Rehearsal mode: build + publish to TestPyPI only, then STOP (no PyPI, no git tag, no notebook commits, no Colab bumps). Used by the Heart/Brain release-validation gate.'
+        required: false
+        default: 'false'
 
 jobs:
   version_number:
@@ -41,6 +45,18 @@ jobs:
           if [ "$RUN_ATTEMPT" -gt "1" ]
           then
               VERSION="$VERSION.$RUN_ATTEMPT"
+          fi
+          # Rehearsal mode (TestPyPI-only; dispatched repeatedly by Heart/Brain).
+          # Append a unique PEP 440 dev segment so every rehearsal run publishes a
+          # FRESH, distinct version. This both dodges TestPyPI's duplicate-filename
+          # rejection AND guarantees the wheels Heart installs reflect the exact
+          # source of *this* run — a bare `--skip-existing` would silently leave
+          # stale wheels from a prior rehearsal of the same date/minor in place.
+          # run_number*100+run_attempt is unique per dispatch and per re-run attempt.
+          if [ "${{ github.event.inputs.rehearsal }}" = "true" ]
+          then
+              DEV_SEGMENT=$(( ${{ github.run_number }} * 100 + RUN_ATTEMPT ))
+              VERSION="${DATE_FORMATTED}.${MINOR_VERSION:-${{ github.run_number }}}.dev${DEV_SEGMENT}"
           fi
           export VERSION
           echo "::set-output name=version_number::${VERSION}"
@@ -94,11 +110,53 @@ jobs:
             python3 -m pip install --upgrade build
             python3 -m build
             popd
+        - name: Check built distributions for direct-reference URLs
+          run: |
+            # Surface the [nss] git+ direct-URL footgun early and loudly. PyPI and
+            # TestPyPI reject any uploaded wheel/sdist whose metadata carries a
+            # PEP 508 direct-reference dependency (e.g. `pkg @ git+https://...`);
+            # twine would otherwise fail the upload with a raw HTTP 400. We fail
+            # here first, naming the offending package and line — this is the exact
+            # packaging-layer bug the rehearsal exists to catch before any release.
+            pushd "${{ matrix.project.path }}"
+            python3 - <<'PY'
+            import glob, re, sys, zipfile, tarfile
+            direct = re.compile(r'^Requires-Dist:.*?@\s+(?:git\+|https?:|file:)', re.IGNORECASE)
+            offending = []
+            def scan(text, origin):
+                for line in text.splitlines():
+                    if direct.match(line):
+                        offending.append((origin, line.strip()))
+            for whl in glob.glob('dist/*.whl'):
+                with zipfile.ZipFile(whl) as z:
+                    for n in z.namelist():
+                        if n.endswith('METADATA'):
+                            scan(z.read(n).decode('utf-8', 'replace'), whl)
+            for sd in glob.glob('dist/*.tar.gz'):
+                with tarfile.open(sd) as t:
+                    for m in t.getmembers():
+                        if m.name.endswith('PKG-INFO'):
+                            f = t.extractfile(m)
+                            if f:
+                                scan(f.read().decode('utf-8', 'replace'), sd)
+            if offending:
+                print('ERROR: direct-reference (git+/url) dependencies in built metadata:')
+                for origin, line in offending:
+                    print(f'  {origin}: {line}')
+                print('TestPyPI/PyPI will reject these (the historical [nss] failure).')
+                sys.exit(1)
+            print('OK: no direct-reference URLs in built distribution metadata.')
+            PY
+            popd
         - name: Upload to test PyPI
           run: |
             python3 -m pip install twine==6.0.1
             pushd "${{ matrix.project.path }}"
-            python3 -m twine upload --repository-url https://test.pypi.org/legacy/ --verbose dist/*
+            # --skip-existing: the rehearsal is dispatched repeatedly, and a re-run
+            # attempt may re-upload a sibling lib that already landed; tolerate the
+            # duplicate-filename case instead of hard-failing. (Freshness of the
+            # rehearsed code is guaranteed separately by the per-run dev version.)
+            python3 -m twine upload --repository-url https://test.pypi.org/legacy/ --skip-existing --verbose dist/*
             popd
         - name: Wait for packages and install
           run: |
@@ -186,7 +244,9 @@ jobs:
     needs:
       - release_test_pypi
       - version_number
-    if: "${{ github.event.inputs.skip_release != 'true' }}"
+    # Skipped in rehearsal mode: rehearsal halts after the TestPyPI publish; the
+    # workspace integration surface is validated downstream by Heart, not here.
+    if: "${{ github.event.inputs.skip_release != 'true' && github.event.inputs.rehearsal != 'true' }}"
     strategy:
       fail-fast: false
       matrix:
@@ -262,6 +322,12 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+    # Rehearsal mode STOPS before PyPI: skipping this job (the git tag/push +
+    # PyPI upload) cascade-skips every job that needs it — publish_release_notes,
+    # release_workspaces, bump_library_colab_urls, run_notebooks_and_release_workspaces,
+    # and (via release_workspaces) wiki_currency_check / wiki_drift_issue. The
+    # full-release path is unchanged when rehearsal is not 'true'.
+    if: "${{ github.event.inputs.rehearsal != 'true' }}"
     env:
       TWINE_REPOSITORY: pypi
       TWINE_USERNAME: __token__
@@ -353,7 +419,7 @@ jobs:
     needs:
       - release
       - version_number
-    if: "${{ github.event.inputs.skip_release != 'true' }}"
+    if: "${{ github.event.inputs.skip_release != 'true' && github.event.inputs.rehearsal != 'true' }}"
     strategy:
       fail-fast: false
       matrix:
@@ -572,7 +638,7 @@ jobs:
     needs:
       - release
       - version_number
-    if: "${{ github.event.inputs.skip_release != 'true' }}"
+    if: "${{ github.event.inputs.skip_release != 'true' && github.event.inputs.rehearsal != 'true' }}"
     strategy:
       fail-fast: false
       matrix:
@@ -733,7 +799,7 @@ jobs:
     needs:
       - version_number
       - release_workspaces
-    if: "${{ github.event.inputs.skip_release != 'true' }}"
+    if: "${{ github.event.inputs.skip_release != 'true' && github.event.inputs.rehearsal != 'true' }}"
     uses: PyAutoLabs/autolens_assistant/.github/workflows/wiki-currency.yml@main
     with:
       stack_version: ${{ needs.version_number.outputs.version_number }}
@@ -768,3 +834,62 @@ jobs:
             --title "wiki drift detected at release $VERSION" \
             --body-file "$BODY" \
           || echo "::warning::could not open wiki-drift issue (non-fatal)"
+
+  # ---------------------------------------------------------------------------
+  # Rehearsal version emitter (rehearsal mode only).
+  #
+  # M1 of the Brain->Health->Heart release-validation redesign. In rehearsal mode
+  # the workflow builds + publishes every package to TestPyPI and STOPS; this job
+  # is the terminal step that records the resolved TestPyPI version so the caller
+  # (the Brain Release Agent / Heart) can `pip install` exactly those wheels.
+  #
+  # Gating on `release_test_pypi` means the artifact exists IFF all five wheels
+  # built, uploaded, and became installable on TestPyPI at this version — so the
+  # artifact's presence is itself the "rehearsal succeeded" signal.
+  # ---------------------------------------------------------------------------
+  rehearsal_version:
+    runs-on: ubuntu-latest
+    needs:
+      - version_number
+      - release_test_pypi
+    if: "${{ github.event.inputs.rehearsal == 'true' }}"
+    steps:
+      - name: Record resolved TestPyPI version
+        run: |
+          VERSION="${{ needs.version_number.outputs.version_number }}"
+          echo "Rehearsal published to TestPyPI at version: $VERSION"
+          mkdir -p rehearsal
+          printf '%s\n' "$VERSION" > rehearsal/testpypi_version.txt
+          cat > rehearsal/rehearsal.json <<JSON
+          {
+            "mode": "rehearsal",
+            "index": "testpypi",
+            "version": "$VERSION",
+            "packages": ["autoconf", "autoarray", "autofit", "autogalaxy", "autolens"],
+            "run_id": "${{ github.run_id }}",
+            "run_attempt": "${{ github.run_attempt }}",
+            "build_sha": "${{ github.sha }}"
+          }
+          JSON
+          cat rehearsal/rehearsal.json
+      - name: Write rehearsal summary
+        run: |
+          VERSION="${{ needs.version_number.outputs.version_number }}"
+          {
+            echo "## TestPyPI rehearsal complete"
+            echo ""
+            echo "Published \`autoconf / autoarray / autofit / autogalaxy / autolens == $VERSION\` to TestPyPI."
+            echo "Halted before PyPI upload, git tags, and workspace notebook commits."
+            echo ""
+            echo "Install exactly these wheels with:"
+            echo '```bash'
+            echo "pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple \\"
+            echo "  autoconf[optional]==$VERSION autoarray[optional]==$VERSION autofit[optional]==$VERSION \\"
+            echo "  autogalaxy[optional]==$VERSION autolens[optional]==$VERSION"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload rehearsal version artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: testpypi-rehearsal-version
+          path: rehearsal/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,20 +9,19 @@ on:
         description: 'Minor version to release'
         required: true
         default: '1'
-      skip_scripts:
-        description: 'Skip scripts'
-        required: false
-        default: 'false'
-      skip_notebooks:
-        description: 'Skip notebooks'
-        required: false
-        default: 'false'
+      # Two orthogonal dispatch axes:
+      #  - rehearsal (mode): false = real release; true = build + publish to
+      #    TestPyPI only, then STOP. The Heart/Brain release-validation gate
+      #    dispatches rehearsal=true (Stage 2); it emits the resolved version and
+      #    cannot mutate anything (no PyPI, no tag, no notebook commits).
+      #  - skip_release (dry-run, only meaningful when rehearsal=false): build to
+      #    TestPyPI but skip every mutation of a real release (PyPI upload, git
+      #    tags, notebook/version commits, Colab bumps).
+      # (The old force-through knobs skip_scripts / skip_notebooks and the
+      # update_notebook_visualisations path were removed with the Heart/Build
+      # split — Build is a pure executor and no longer needs ad-hoc skip levers.)
       skip_release:
-        description: 'Skip release'
-        required: false
-        default: 'false'
-      update_notebook_visualisations:
-        description: 'Update notebook visualisations'
+        description: 'Dry run: build + publish to TestPyPI but skip the real release (no PyPI upload, no git tags, no workspace commits).'
         required: false
         default: 'false'
       rehearsal:
@@ -324,19 +323,19 @@ jobs:
     runs-on: ubuntu-latest
     # Rehearsal mode STOPS before PyPI: skipping this job (the git tag/push +
     # PyPI upload) cascade-skips every job that needs it — publish_release_notes,
-    # release_workspaces, bump_library_colab_urls, run_notebooks_and_release_workspaces,
-    # and (via release_workspaces) wiki_currency_check / wiki_drift_issue. The
-    # full-release path is unchanged when rehearsal is not 'true'.
+    # release_workspaces, bump_library_colab_urls, and (via release_workspaces)
+    # wiki_currency_check / wiki_drift_issue. The full-release path is unchanged
+    # when rehearsal is not 'true'.
     if: "${{ github.event.inputs.rehearsal != 'true' }}"
     env:
       TWINE_REPOSITORY: pypi
       TWINE_USERNAME: __token__
       TWINE_PASSWORD: ${{ secrets.PYPI }}
     needs:
-      # Workspace-integration validation moved to PyAutoPulse
+      # Workspace-integration validation moved to PyAutoHeart
       # (workspace-validation.yml). Build is a pure executor: it gates only on
       # the TestPyPI build + version. Release readiness is enforced upstream by
-      # the PyAutoAgent release agent via `pyauto-pulse readiness`.
+      # the release agent via `pyauto-heart readiness`.
       - release_test_pypi
       - version_number
     strategy:
@@ -456,7 +455,7 @@ jobs:
       TWINE_PASSWORD: ${{ secrets.PYPI }}
       PAT: ${{ secrets.PAT_PYAUTOLABS }}
     needs:
-      # Validation moved to PyAutoPulse; this job generates notebooks inline and
+      # Validation moved to PyAutoHeart; this job generates notebooks inline and
       # commits them — it no longer gates on the (removed) run_scripts/run_notebooks.
       # Gate on `release`: workspace version pins must only be written after the
       # libraries actually publish to PyPI, else a workspace could pin a version
@@ -667,122 +666,6 @@ jobs:
           git commit -m "Release $VERSION: bump Colab URL tag refs"
           git push origin main
         fi
-
-  run_notebooks_and_release_workspaces:
-    runs-on: ubuntu-latest
-    env:
-      TWINE_REPOSITORY: pypi
-      TWINE_USERNAME: __token__
-      TWINE_PASSWORD: ${{ secrets.PYPI }}
-    needs:
-      # Validation moved to PyAutoPulse; this job generates + runs notebooks
-      # inline (its own matrix). Gate on `release` (same reason as
-      # release_workspaces) so it only runs after PyPI publish succeeds.
-      - release
-      - release_test_pypi
-      - version_number
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [ 3.12 ]
-        project:
-          - name: autofit
-            repository: PyAutoLabs/PyAutoFit
-            workspace_repository: PyAutoLabs/autofit_workspace
-            pat: PAT_PYAUTOLABS
-          - name: autogalaxy
-            repository: PyAutoLabs/PyAutoGalaxy
-            workspace_repository: PyAutoLabs/autogalaxy_workspace
-            pat: PAT_PYAUTOLABS
-          - name: autolens
-            repository: PyAutoLabs/PyAutoLens
-            workspace_repository: PyAutoLabs/autolens_workspace
-            pat: PAT_PYAUTOLABS
-    steps:
-      - name: Configure
-        id: configure
-        if: "${{ github.event.inputs.update_notebook_visualisations == 'true' }}"
-        run: |
-          echo "::set-output name=repository::${{ matrix.project.repository }}"
-          echo "::set-output name=workspace_repository::${{ matrix.project.workspace_repository }}"
-          echo "::set-output name=project::${{ matrix.project.name }}"
-          echo "::set-output name=pat::${{ matrix.project.pat }}"
-      - uses: actions/checkout@v2
-        if: "${{ github.event.inputs.update_notebook_visualisations == 'true' }}"
-        with:
-          path: PyAutoBuild
-      - name: Checkout project
-        if: "${{ github.event.inputs.update_notebook_visualisations == 'true' }}"
-        uses: actions/checkout@v2
-        with:
-          repository: "${{ steps.configure.outputs.repository }}"
-          path: project
-      - name: Checkout workspace
-        if: "${{ github.event.inputs.update_notebook_visualisations == 'true' }}"
-        run: |
-          PAT="${{ secrets[steps.configure.outputs.pat] }}"
-          git clone -b main "https://$PAT@github.com/${{ steps.configure.outputs.workspace_repository }}.git" workspace
-      - name: Set up Python ${{ matrix.python-version }}
-        if: "${{ github.event.inputs.update_notebook_visualisations == 'true' }}"
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install optional requirements
-        if: "${{ github.event.inputs.update_notebook_visualisations == 'true' }}"
-        run: |
-          echo "Installing optional requirements"
-          pip install matplotlib==3.6.0
-          pip install pynufft==2025.1.1
-          pip install numba
-      - name: Install project
-        if: "${{ github.event.inputs.update_notebook_visualisations == 'true' }}"
-        run: |
-          python3 -m pip install \
-            --index-url https://test.pypi.org/simple/ \
-            --extra-index-url https://pypi.org/simple \
-            "${{ steps.configure.outputs.project }}==${{ needs.version_number.outputs.version_number }}"
-      - name: Install Jupyter dependency
-        if: "${{ github.event.inputs.update_notebook_visualisations == 'true' }}"
-        run: |
-          python3 -m pip install jupyter ipynb-py-convert
-      - name: Generate Jupyter notebooks
-        if: "${{ github.event.inputs.update_notebook_visualisations == 'true' }}"
-        run: |
-          export PYTHONPATH=$PYTHONPATH:$(pwd)/PyAutoBuild
-          AUTOBUILD_PATH="$(pwd)/PyAutoBuild/autobuild"
-          pushd "workspace"
-          python3 "$AUTOBUILD_PATH/generate.py" ${{ matrix.project.name }}
-      - name: Run Jupyter notebooks
-        if: "${{ github.event.inputs.update_notebook_visualisations == 'true' }}"
-        run: |
-          if [[ ${{ matrix.project.name }} == *_test ]]
-          then
-            export PYAUTO_TEST_MODE=0
-          else
-            export PYAUTO_TEST_MODE=1
-            export PYAUTO_SMALL_DATASETS=1
-            export PYAUTO_FAST_PLOTS=1
-          fi
-          export PYTHONPATH=$PYTHONPATH:$(pwd)/PyAutoBuild
-          AUTOBUILD_PATH="$(pwd)/PyAutoBuild/autobuild"
-          pushd workspace
-          python3 "$AUTOBUILD_PATH/run.py" ${{ matrix.project.name }} "notebooks/${{ matrix.project.directory }}" --visualise
-      - name: Configure Git
-        if: "${{ github.event.inputs.update_notebook_visualisations == 'true' }}"
-        run: |
-          git config --global user.email "richard@rghsoftware.co.uk"
-          git config --global user.name "GitHub Actions bot"
-      - name: Commit visualizations
-        if: "${{ github.event.inputs.update_notebook_visualisations == 'true' }}"
-        run: |
-          cd workspace
-          git add .
-          git commit -m "Updated notebooks with visualizations" || true
-      - name: Push to main
-        if: "${{ github.event.inputs.update_notebook_visualisations == 'true' }}"
-        run: |
-          cd workspace
-          git push origin main
 
   # ---------------------------------------------------------------------------
   # Wiki-currency check (autolens_assistant).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,21 +9,14 @@ on:
         description: 'Minor version to release'
         required: true
         default: '1'
-      # Two orthogonal dispatch axes:
-      #  - rehearsal (mode): false = real release; true = build + publish to
-      #    TestPyPI only, then STOP. The Heart/Brain release-validation gate
-      #    dispatches rehearsal=true (Stage 2); it emits the resolved version and
-      #    cannot mutate anything (no PyPI, no tag, no notebook commits).
-      #  - skip_release (dry-run, only meaningful when rehearsal=false): build to
-      #    TestPyPI but skip every mutation of a real release (PyPI upload, git
-      #    tags, notebook/version commits, Colab bumps).
-      # (The old force-through knobs skip_scripts / skip_notebooks and the
-      # update_notebook_visualisations path were removed with the Heart/Build
-      # split — Build is a pure executor and no longer needs ad-hoc skip levers.)
-      skip_release:
-        description: 'Dry run: build + publish to TestPyPI but skip the real release (no PyPI upload, no git tags, no workspace commits).'
-        required: false
-        default: 'false'
+      # rehearsal is the one mode switch: false (default) = a full real release;
+      # true = build + publish to TestPyPI only, then STOP. The Heart/Brain
+      # release-validation gate dispatches rehearsal=true (Stage 2); it emits the
+      # resolved version and cannot mutate anything (no PyPI, no tag, no commits).
+      # (The old force-through knobs skip_scripts / skip_notebooks / skip_release
+      # and the update_notebook_visualisations path were removed with the
+      # Heart/Build split — Build is a pure executor with no ad-hoc skip levers;
+      # "build without releasing" is now exactly what rehearsal mode is for.)
       rehearsal:
         description: 'Rehearsal mode: build + publish to TestPyPI only, then STOP (no PyPI, no git tag, no notebook commits, no Colab bumps). Used by the Heart/Brain release-validation gate.'
         required: false
@@ -245,7 +238,7 @@ jobs:
       - version_number
     # Skipped in rehearsal mode: rehearsal halts after the TestPyPI publish; the
     # workspace integration surface is validated downstream by Heart, not here.
-    if: "${{ github.event.inputs.skip_release != 'true' && github.event.inputs.rehearsal != 'true' }}"
+    if: "${{ github.event.inputs.rehearsal != 'true' }}"
     strategy:
       fail-fast: false
       matrix:
@@ -363,33 +356,27 @@ jobs:
           pat: PAT_PYAUTOLABS
     steps:
     - uses: actions/checkout@v2
-      if: "${{ github.event.inputs.skip_release != 'true' }}"
       with:
           path: PyAutoBuild
     - name: Checkout
-      if: "${{ github.event.inputs.skip_release != 'true' }}"
       run: |
         PAT="${{ secrets[matrix.project.pat] }}"
         git clone -b "${{ matrix.project.ref }}" "https://$PAT@github.com/${{ matrix.project.repository }}.git" "${{ matrix.project.path }}"
     - name: Set up Python 3.12
       uses: actions/setup-python@v2
-      if: "${{ github.event.inputs.skip_release != 'true' }}"
       with:
         python-version: "3.12"
     - name: Configure Git
-      if: "${{ github.event.inputs.skip_release != 'true' }}"
       run: |
         git config --global user.email "richard@rghsoftware.co.uk"
         git config --global user.name "GitHub Actions bot"
     - name: Update version
-      if: "${{ github.event.inputs.skip_release != 'true' }}"
       run: |
         pushd "${{ matrix.project.path }}"
         VERSION="${{ needs.version_number.outputs.version_number }}"
         sed -i "s/__version__ = [\.\"\'0-9]*/__version__ = \"$VERSION\"/g" */__init__.py
         git commit "-am 'Updated version in __init__ to $VERSION"
     - name: Tag
-      if: "${{ github.event.inputs.skip_release != 'true' }}"
       run: |
         pushd "${{ matrix.project.path }}"
         VERSION="${{ needs.version_number.outputs.version_number }}"
@@ -399,7 +386,6 @@ jobs:
         git push
         git push --tags
     - name: Build
-      if: "${{ github.event.inputs.skip_release != 'true' }}"
       run: |
         pushd "${{ matrix.project.path }}"
         export VERSION="${{ needs.version_number.outputs.version_number }}"
@@ -407,7 +393,6 @@ jobs:
         python3 -m pip install --upgrade build
         python3 -m build
     - name: Upload to PyPI
-      if: "${{ github.event.inputs.skip_release != 'true' }}"
       run: |
         python3 -m pip install twine==6.0.1
         pushd "${{ matrix.project.path }}"
@@ -418,7 +403,7 @@ jobs:
     needs:
       - release
       - version_number
-    if: "${{ github.event.inputs.skip_release != 'true' && github.event.inputs.rehearsal != 'true' }}"
+    if: "${{ github.event.inputs.rehearsal != 'true' }}"
     strategy:
       fail-fast: false
       matrix:
@@ -511,29 +496,23 @@ jobs:
             write_api_baseline: true
     steps:
     - uses: actions/checkout@v2
-      if: "${{ github.event.inputs.skip_release != 'true' }}"
       with:
           path: PyAutoBuild
     - name: Checkout
-      if: "${{ github.event.inputs.skip_release != 'true' }}"
       run: |
         git clone -b main "https://$PAT@github.com/${{ matrix.workspace.repository }}.git" workspace
     - name: Configure Git
-      if: "${{ github.event.inputs.skip_release != 'true' }}"
       run: |
         git config --global user.email "richard@rghsoftware.co.uk"
         git config --global user.name "GitHub Actions bot"
     - name: Set up Python ${{ matrix.python-version }}
-      if: "${{ github.event.inputs.skip_release != 'true' }}"
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Jupyter dependency
-      if: "${{ github.event.inputs.skip_release != 'true' }}"
       run: |
         pip install jupyter ipynb-py-convert PyYAML
     - name: Update version in README
-      if: "${{ github.event.inputs.skip_release != 'true' }}"
       run: |
         VERSION="${{ needs.version_number.outputs.version_number }}"
         PACKAGE="${{ matrix.workspace.package }}"
@@ -541,7 +520,7 @@ jobs:
         sed -i "s/$PACKAGE v[0-9]\{4\}\.[0-9]*\.[0-9]*\.[0-9]*/$PACKAGE v$VERSION/g" README.rst README.md 2>/dev/null || true
         git add README.rst README.md 2>/dev/null || true
     - name: Update jupyter notebooks
-      if: "${{ github.event.inputs.skip_release != 'true' && matrix.workspace.generate_notebooks == true }}"
+      if: "${{ matrix.workspace.generate_notebooks == true }}"
       run: |
         export PYTHONPATH=$PYTHONPATH:$(pwd)/PyAutoBuild
         AUTOBUILD_PATH="$(pwd)/PyAutoBuild/autobuild"
@@ -550,7 +529,6 @@ jobs:
         git add *.ipynb
         git commit -m "Release ${{ needs.version_number.outputs.version_number }}: update notebooks and version" || true
     - name: Write workspace version
-      if: "${{ github.event.inputs.skip_release != 'true' }}"
       run: |
         VERSION="${{ needs.version_number.outputs.version_number }}"
         pushd workspace
@@ -578,7 +556,7 @@ jobs:
         git add version.txt config/general.yaml 2>/dev/null || git add version.txt
         git commit -m "Release $VERSION: pin workspace version" || true
     - name: Regenerate API audit baseline
-      if: "${{ github.event.inputs.skip_release != 'true' && matrix.workspace.write_api_baseline == true }}"
+      if: "${{ matrix.workspace.write_api_baseline == true }}"
       env:
         NUMBA_CACHE_DIR: /tmp/numba_cache
         MPLCONFIGDIR: /tmp/matplotlib
@@ -613,7 +591,7 @@ jobs:
         git commit -m "Release $VERSION: regenerate API audit baseline" || true
         popd
     - name: Bump Colab URL tag refs
-      if: "${{ github.event.inputs.skip_release != 'true' && matrix.workspace.bump_colab_urls == true }}"
+      if: "${{ matrix.workspace.bump_colab_urls == true }}"
       run: |
         VERSION="${{ needs.version_number.outputs.version_number }}"
         pushd workspace
@@ -621,7 +599,6 @@ jobs:
         git add -A
         git commit -m "Release $VERSION: bump Colab URL tag refs" || true
     - name: Tag and push to main
-      if: "${{ github.event.inputs.skip_release != 'true' }}"
       run: |
         cd workspace
         VERSION="${{ needs.version_number.outputs.version_number }}"
@@ -637,7 +614,7 @@ jobs:
     needs:
       - release
       - version_number
-    if: "${{ github.event.inputs.skip_release != 'true' && github.event.inputs.rehearsal != 'true' }}"
+    if: "${{ github.event.inputs.rehearsal != 'true' }}"
     strategy:
       fail-fast: false
       matrix:
@@ -682,7 +659,7 @@ jobs:
     needs:
       - version_number
       - release_workspaces
-    if: "${{ github.event.inputs.skip_release != 'true' && github.event.inputs.rehearsal != 'true' }}"
+    if: "${{ github.event.inputs.rehearsal != 'true' }}"
     uses: PyAutoLabs/autolens_assistant/.github/workflows/wiki-currency.yml@main
     with:
       stack_version: ${{ needs.version_number.outputs.version_number }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,38 +2,38 @@
 
 PyAutoBuild is the **executor** of the PyAuto release ecosystem: packaging,
 tagging, notebook generation, and PyPI publication via `release.yml`. It runs no
-release-readiness checks of its own — that is PyAutoPulse's job.
+release-readiness checks of its own — that is PyAutoHeart's job.
 
 ## The boundary (one description, mirrored in all three repos)
 
-- **PyAutoPulse — the health authority.** All health/readiness logic lives here:
+- **PyAutoHeart — the health authority.** All health/readiness logic lives here:
   version drift, install-path, URL hygiene, CI/worktree/timing monitoring.
-  `pyauto-pulse readiness` is the **authoritative** green/yellow/red verdict —
-  the single "is it safe to release?" gate. Pulse is an observer: it reads and
+  `pyauto-heart readiness` is the **authoritative** green/yellow/red verdict —
+  the single "is it safe to release?" gate. Heart is an observer: it reads and
   emits verdicts; it never writes into other repos and never triggers Build.
 - **PyAutoBuild — the executor.** Packaging, tagging, notebook generation, and
   PyPI publication via `release.yml`. Build runs **no** readiness checks of its
   own and never re-derives a gate decision; it just executes.
 - **PyAutoAgent — the brain.** Hosts the agents that connect the two. It owns no
-  checks and no release steps; it gates on Pulse and delegates execution to
+  checks and no release steps; it gates on Heart and delegates execution to
   Build.
 
 ## The call chain (always this order)
 
 ```
-Agent  →  Pulse (gate)  →  Build (execute)
+Agent  →  Heart (gate)  →  Build (execute)
 ```
 
-The agent asks `pyauto-pulse readiness --json`; only on a **green** verdict does
-it trigger Build's release. Pulse never triggers Build; Build never re-derives a
+The agent asks `pyauto-heart readiness --json`; only on a **green** verdict does
+it trigger Build's release. Heart never triggers Build; Build never re-derives a
 gate decision the agent already made.
 
 ## What moved out of Build
 
 Release-readiness checking is no longer Build's job. The version-skew gate, the
-deep `verify_install` suite, and URL hygiene all live in PyAutoPulse now;
+deep `verify_install` suite, and URL hygiene all live in PyAutoHeart now;
 `autobuild verify_install` / `autobuild url_check` / `autobuild watch|status|
-tick|fix` are thin shims that delegate to `pyauto-pulse`. Build keeps only the
+tick|fix` are thin shims that delegate to `pyauto-heart`. Build keeps only the
 executor primitives (`pre_build`, `generate`, `run*`, `tag_and_merge`,
 `bump_colab_urls`, `release.yml`).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,14 +14,14 @@ release-readiness checks of its own — that is PyAutoHeart's job.
 - **PyAutoBuild — the executor.** Packaging, tagging, notebook generation, and
   PyPI publication via `release.yml`. Build runs **no** readiness checks of its
   own and never re-derives a gate decision; it just executes.
-- **PyAutoAgent — the brain.** Hosts the agents that connect the two. It owns no
+- **PyAutoBrain — the brain.** Hosts the agents that connect the two. It owns no
   checks and no release steps; it gates on Heart and delegates execution to
   Build.
 
 ## The call chain (always this order)
 
 ```
-Agent  →  Heart (gate)  →  Build (execute)
+Brain  →  Heart (gate)  →  Build (execute)
 ```
 
 The agent asks `pyauto-heart readiness --json`; only on a **green** verdict does

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Project Does
 
-PyAutoBuild is the **executor** of the PyAuto release ecosystem (PyAutoConf, PyAutoFit, PyAutoArray, PyAutoGalaxy, PyAutoLens) — it runs **no** release-readiness checks of its own (that is PyAutoPulse's job; see [`AGENTS.md`](AGENTS.md) for the canonical Build/Pulse/Agent boundary and the `Agent → Pulse → Build` call chain). It automates:
+PyAutoBuild is the **executor** of the PyAuto release ecosystem (PyAutoConf, PyAutoFit, PyAutoArray, PyAutoGalaxy, PyAutoLens) — it runs **no** release-readiness checks of its own (that is PyAutoHeart's job; see [`AGENTS.md`](AGENTS.md) for the canonical Build/Heart/Agent boundary and the `Agent → Heart → Build` call chain). It automates:
 1. Building and releasing packages to TestPyPI, then PyPI
 2. Running workspace Python scripts (integration tests)
 3. Converting Python scripts to Jupyter notebooks and executing them
 4. Committing generated notebooks to workspace `main` branches and tagging each workspace with a version matching the released library
 
-The pipeline is triggered via GitHub Actions (`release.yml`) and is manually dispatched with configurable options. Release-readiness gating happens upstream: the PyAutoAgent release agent calls `pyauto-pulse readiness` and only dispatches `release.yml` on a green verdict.
+The pipeline is triggered via GitHub Actions (`release.yml`) and is manually dispatched with configurable options. Release-readiness gating happens upstream: the PyAutoAgent release agent calls `pyauto-heart readiness` and only dispatches `release.yml` on a green verdict.
 
 ## Bash CLI
 
@@ -51,7 +51,7 @@ This script does the following for each repo:
 
 Before the per-repo loop, `pre_build.sh` invokes `admin_jammy/software/ensure_workspace_labels.sh` to assert the canonical `pending-release` label across every release-window repo (idempotent — a no-op when nothing has drifted).
 
-Release-readiness checking is **not** Build's job — PyAutoBuild is a pure executor. The version-skew check that used to live here (`verify_workspace_versions.sh`, a fail-fast guard against a workspace pinned ahead of its installed library, or a `config/general.yaml` ↔ `version.txt` disagreement) now lives in **PyAutoPulse** as the `version_skew` check feeding `pyauto-pulse readiness`. The PyAutoAgent release agent gates on `pyauto-pulse readiness` before invoking `pre_build`; a human running `pre_build` directly is trusted to have checked readiness first. See PyAutoPulse for the resolution precedence (`config/general.yaml:version.workspace_version`, then `version.txt`) — identical to `autoconf.workspace.check_version`, so workspace/library mismatches still surface on every script run via each library's `__init__.py`.
+Release-readiness checking is **not** Build's job — PyAutoBuild is a pure executor. The version-skew check that used to live here (`verify_workspace_versions.sh`, a fail-fast guard against a workspace pinned ahead of its installed library, or a `config/general.yaml` ↔ `version.txt` disagreement) now lives in **PyAutoHeart** as the `version_skew` check feeding `pyauto-heart readiness`. The PyAutoAgent release agent gates on `pyauto-heart readiness` before invoking `pre_build`; a human running `pre_build` directly is trusted to have checked readiness first. See PyAutoHeart for the resolution precedence (`config/general.yaml:version.workspace_version`, then `version.txt`) — identical to `autoconf.workspace.check_version`, so workspace/library mismatches still surface on every script run via each library's `__init__.py`.
 
 `generate.py` is run from the workspace root with `PYTHONPATH` pointing at `PyAutoBuild/autobuild/`. Only specific safe directories are committed — never `output/`, `output_model/`, or run-generated artefacts. After all workspaces are done, PyAutoBuild itself is committed and pushed, then `gh workflow run release.yml` dispatches the GitHub Actions release.
 
@@ -105,7 +105,7 @@ All scripts in `autobuild/` are run from within a checked-out workspace director
 - **`generate.py <project>`** — Converts Python scripts in `scripts/` to `.ipynb` notebooks in `notebooks/`, run from within the workspace root
 - **`script_matrix.py <project1> [project2 ...]`** — Outputs a JSON matrix of `{name, directory}` pairs for GitHub Actions matrix strategy
 - **`tag_and_merge.sh --version <version>`** — Commits pending changes and tags library repos (PyAutoConf, PyAutoFit, PyAutoArray, PyAutoGalaxy, PyAutoLens) for release
-- **`url_check`** — URL hygiene moved to PyAutoPulse (Pulse owns all health checking). `autobuild url_check` is now a thin shim to `pyauto-pulse url_check`; the ecosystem-wide sweep runs from PyAutoPulse's central `url-check.yml` workflow (replacing the old per-repo `url_check.yml` workflows). The runnable scripts live at `PyAutoPulse/pulse/checks/url_check*.{sh,py}`.
+- **`url_check`** — URL hygiene moved to PyAutoHeart (Heart owns all health checking). `autobuild url_check` is now a thin shim to `pyauto-heart url_check`; the ecosystem-wide sweep runs from PyAutoHeart's central `url-check.yml` workflow (replacing the old per-repo `url_check.yml` workflows). The runnable scripts live at `PyAutoHeart/heart/checks/url_check*.{sh,py}`.
 - **`bump_colab_urls.sh <new-tag>`** — Rewrites every `colab.research.google.com/github/PyAutoLabs/<repo>/blob/<old-tag>/...` URL in cwd to use `<new-tag>`, where `<repo>` is one of `autofit_workspace`, `autogalaxy_workspace`, `autolens_workspace`, `HowToGalaxy`, `HowToLens`. Called by the `release_workspaces` and `bump_library_colab_urls` jobs in `release.yml` so README/docs Colab links always pin to the just-released tag. Idempotent; skips URLs not in canonical PyAutoLabs/date-tagged form.
 
 ## Architecture
@@ -148,10 +148,18 @@ Each workspace owns its own build config under `<workspace>/config/build/`:
 
 The workflow (`release.yml`) is manually dispatched with inputs:
 - `minor_version` — appended to date-based version (format: `YYYY.M.D.minor`)
-- `skip_scripts` / `skip_notebooks` / `skip_release` — flags to skip pipeline stages
-- `update_notebook_visualisations` — runs notebooks with `--visualise` and pushes the rendered output to `main`
+- `rehearsal` — TestPyPI-only rehearsal mode: build every package from source, publish to
+  TestPyPI, emit the resolved version as the `testpypi-rehearsal-version` artifact, then STOP
+  (no PyPI upload, no git tag, no notebook/version commits, no Colab bumps). This is the mode the
+  Heart/Brain release-validation gate dispatches so it can install and validate the built wheels.
+- `skip_release` — dry run: build + publish to TestPyPI but skip the real release (no PyPI upload,
+  no git tags, no workspace commits). Only meaningful when `rehearsal` is false.
 
-`release.yml` is a **pure executor**: it builds, tests-the-install, publishes to PyPI, and commits generated notebooks + version pins to the workspaces. Workspace-integration validation (the old `find_scripts` / `generate_notebooks` / `run_scripts` / `run_notebooks` / `analyze_results` jobs) moved to **PyAutoPulse**'s `workspace-validation.yml`; release readiness is gated upstream by the PyAutoAgent release agent via `pyauto-pulse readiness` before this workflow is dispatched. The `script_matrix.py` / `run_python.py` / `run.py` / `aggregate_results.py` primitives remain here and are checked out + reused by the Pulse workflow.
+(The legacy `skip_scripts` / `skip_notebooks` force-through knobs and the
+`update_notebook_visualisations` path were removed with the Heart/Build split — Build is a pure
+executor and no longer carries ad-hoc skip levers or an inline notebook-visualisation job.)
+
+`release.yml` is a **pure executor**: it builds, tests-the-install, publishes to PyPI, and commits generated notebooks + version pins to the workspaces. Workspace-integration validation (the old `find_scripts` / `generate_notebooks` / `run_scripts` / `run_notebooks` / `analyze_results` jobs) moved to **PyAutoHeart**'s `workspace-validation.yml`; release readiness is gated upstream by the PyAutoAgent release agent via `pyauto-heart readiness` before this workflow is dispatched. The `script_matrix.py` / `run_python.py` / `run.py` / `aggregate_results.py` primitives remain here and are checked out + reused by the Heart workflow.
 ## Never rewrite history
 
 NEVER perform these operations on any repo with a remote:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Project Does
 
-PyAutoBuild is the **executor** of the PyAuto release ecosystem (PyAutoConf, PyAutoFit, PyAutoArray, PyAutoGalaxy, PyAutoLens) — it runs **no** release-readiness checks of its own (that is PyAutoHeart's job; see [`AGENTS.md`](AGENTS.md) for the canonical Build/Heart/Agent boundary and the `Agent → Heart → Build` call chain). It automates:
+PyAutoBuild is the **executor** of the PyAuto release ecosystem (PyAutoConf, PyAutoFit, PyAutoArray, PyAutoGalaxy, PyAutoLens) — it runs **no** release-readiness checks of its own (that is PyAutoHeart's job; see [`AGENTS.md`](AGENTS.md) for the canonical Build/Heart/Brain boundary and the `Brain → Heart → Build` call chain). It automates:
 1. Building and releasing packages to TestPyPI, then PyPI
 2. Running workspace Python scripts (integration tests)
 3. Converting Python scripts to Jupyter notebooks and executing them
 4. Committing generated notebooks to workspace `main` branches and tagging each workspace with a version matching the released library
 
-The pipeline is triggered via GitHub Actions (`release.yml`) and is manually dispatched with configurable options. Release-readiness gating happens upstream: the PyAutoAgent release agent calls `pyauto-heart readiness` and only dispatches `release.yml` on a green verdict.
+The pipeline is triggered via GitHub Actions (`release.yml`) and is manually dispatched with configurable options. Release-readiness gating happens upstream: the PyAutoBrain release agent calls `pyauto-heart readiness` and only dispatches `release.yml` on a green verdict.
 
 ## Bash CLI
 
@@ -51,7 +51,7 @@ This script does the following for each repo:
 
 Before the per-repo loop, `pre_build.sh` invokes `admin_jammy/software/ensure_workspace_labels.sh` to assert the canonical `pending-release` label across every release-window repo (idempotent — a no-op when nothing has drifted).
 
-Release-readiness checking is **not** Build's job — PyAutoBuild is a pure executor. The version-skew check that used to live here (`verify_workspace_versions.sh`, a fail-fast guard against a workspace pinned ahead of its installed library, or a `config/general.yaml` ↔ `version.txt` disagreement) now lives in **PyAutoHeart** as the `version_skew` check feeding `pyauto-heart readiness`. The PyAutoAgent release agent gates on `pyauto-heart readiness` before invoking `pre_build`; a human running `pre_build` directly is trusted to have checked readiness first. See PyAutoHeart for the resolution precedence (`config/general.yaml:version.workspace_version`, then `version.txt`) — identical to `autoconf.workspace.check_version`, so workspace/library mismatches still surface on every script run via each library's `__init__.py`.
+Release-readiness checking is **not** Build's job — PyAutoBuild is a pure executor. The version-skew check that used to live here (`verify_workspace_versions.sh`, a fail-fast guard against a workspace pinned ahead of its installed library, or a `config/general.yaml` ↔ `version.txt` disagreement) now lives in **PyAutoHeart** as the `version_skew` check feeding `pyauto-heart readiness`. The PyAutoBrain release agent gates on `pyauto-heart readiness` before invoking `pre_build`; a human running `pre_build` directly is trusted to have checked readiness first. See PyAutoHeart for the resolution precedence (`config/general.yaml:version.workspace_version`, then `version.txt`) — identical to `autoconf.workspace.check_version`, so workspace/library mismatches still surface on every script run via each library's `__init__.py`.
 
 `generate.py` is run from the workspace root with `PYTHONPATH` pointing at `PyAutoBuild/autobuild/`. Only specific safe directories are committed — never `output/`, `output_model/`, or run-generated artefacts. After all workspaces are done, PyAutoBuild itself is committed and pushed, then `gh workflow run release.yml` dispatches the GitHub Actions release.
 
@@ -148,18 +148,18 @@ Each workspace owns its own build config under `<workspace>/config/build/`:
 
 The workflow (`release.yml`) is manually dispatched with inputs:
 - `minor_version` — appended to date-based version (format: `YYYY.M.D.minor`)
-- `rehearsal` — TestPyPI-only rehearsal mode: build every package from source, publish to
-  TestPyPI, emit the resolved version as the `testpypi-rehearsal-version` artifact, then STOP
-  (no PyPI upload, no git tag, no notebook/version commits, no Colab bumps). This is the mode the
-  Heart/Brain release-validation gate dispatches so it can install and validate the built wheels.
-- `skip_release` — dry run: build + publish to TestPyPI but skip the real release (no PyPI upload,
-  no git tags, no workspace commits). Only meaningful when `rehearsal` is false.
+- `rehearsal` — the one mode switch (default `false` = full real release). When `true`, it is
+  TestPyPI-only rehearsal mode: build every package from source, publish to TestPyPI, emit the
+  resolved version as the `testpypi-rehearsal-version` artifact, then STOP (no PyPI upload, no git
+  tag, no notebook/version commits, no Colab bumps). This is the mode the Heart/Brain
+  release-validation gate dispatches so it can install and validate the built wheels.
 
-(The legacy `skip_scripts` / `skip_notebooks` force-through knobs and the
+(The legacy `skip_scripts` / `skip_notebooks` / `skip_release` force-through knobs and the
 `update_notebook_visualisations` path were removed with the Heart/Build split — Build is a pure
-executor and no longer carries ad-hoc skip levers or an inline notebook-visualisation job.)
+executor with no ad-hoc skip levers or inline notebook-visualisation job. "Build without
+releasing" is now exactly what `rehearsal` mode is for.)
 
-`release.yml` is a **pure executor**: it builds, tests-the-install, publishes to PyPI, and commits generated notebooks + version pins to the workspaces. Workspace-integration validation (the old `find_scripts` / `generate_notebooks` / `run_scripts` / `run_notebooks` / `analyze_results` jobs) moved to **PyAutoHeart**'s `workspace-validation.yml`; release readiness is gated upstream by the PyAutoAgent release agent via `pyauto-heart readiness` before this workflow is dispatched. The `script_matrix.py` / `run_python.py` / `run.py` / `aggregate_results.py` primitives remain here and are checked out + reused by the Heart workflow.
+`release.yml` is a **pure executor**: it builds, tests-the-install, publishes to PyPI, and commits generated notebooks + version pins to the workspaces. Workspace-integration validation (the old `find_scripts` / `generate_notebooks` / `run_scripts` / `run_notebooks` / `analyze_results` jobs) moved to **PyAutoHeart**'s `workspace-validation.yml`; release readiness is gated upstream by the PyAutoBrain release agent via `pyauto-heart readiness` before this workflow is dispatched. The `script_matrix.py` / `run_python.py` / `run.py` / `aggregate_results.py` primitives remain here and are checked out + reused by the Heart workflow.
 ## Never rewrite history
 
 NEVER perform these operations on any repo with a remote:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PyAutoBuild: PyAuto Build Server
 
-PyAutoBuild is the **executor** of the PyAuto release ecosystem — it builds, tests and deploys, but runs no release-readiness checks (those belong to [PyAutoPulse](https://github.com/PyAutoLabs/PyAutoPulse); the [PyAutoAgent](https://github.com/PyAutoLabs/PyAutoAgent) release agent gates on `pyauto-pulse readiness` before dispatching a release). See `AGENTS.md` for the boundary.
+PyAutoBuild is the **executor** of the PyAuto release ecosystem — it builds, tests and deploys, but runs no release-readiness checks (those belong to [PyAutoHeart](https://github.com/PyAutoLabs/PyAutoHeart); the [PyAutoAgent](https://github.com/PyAutoLabs/PyAutoAgent) release agent gates on `pyauto-heart readiness` before dispatching a release). See `AGENTS.md` for the boundary.
 
 This project performs automatic building, testing and deployment of projects in the PyAuto software family:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PyAutoBuild: PyAuto Build Server
 
-PyAutoBuild is the **executor** of the PyAuto release ecosystem — it builds, tests and deploys, but runs no release-readiness checks (those belong to [PyAutoHeart](https://github.com/PyAutoLabs/PyAutoHeart); the [PyAutoAgent](https://github.com/PyAutoLabs/PyAutoAgent) release agent gates on `pyauto-heart readiness` before dispatching a release). See `AGENTS.md` for the boundary.
+PyAutoBuild is the **executor** of the PyAuto release ecosystem — it builds, tests and deploys, but runs no release-readiness checks (those belong to [PyAutoHeart](https://github.com/PyAutoLabs/PyAutoHeart); the [PyAutoBrain](https://github.com/PyAutoLabs/PyAutoBrain) release agent gates on `pyauto-heart readiness` before dispatching a release). See `AGENTS.md` for the boundary.
 
 This project performs automatic building, testing and deployment of projects in the PyAuto software family:
 

--- a/pre_build.sh
+++ b/pre_build.sh
@@ -6,17 +6,11 @@
 # Usage: bash pre_build.sh [minor_version] [skip_release]
 #   minor_version  Minor version suffix (default: 1)
 #   skip_release   Whether to skip the release stage, true or false (default: false)
-#
-# Optional env vars (forwarded as workflow_dispatch inputs when set):
-#   SKIP_SCRIPTS    true|false — skip run_scripts matrix in release.yml
-#   SKIP_NOTEBOOKS  true|false — skip run_notebooks matrix in release.yml
 
 set -e
 
 MINOR_VERSION="${1:-1}"
 SKIP_RELEASE="${2:-false}"
-SKIP_SCRIPTS="${SKIP_SCRIPTS:-}"
-SKIP_NOTEBOOKS="${SKIP_NOTEBOOKS:-}"
 
 # Resolve PYAUTOBASE from this script's location (same idiom as bin/autobuild)
 # so pre_build.sh works from any checkout — Linux, WSL, anywhere.
@@ -117,26 +111,18 @@ else
 fi
 
 # Release readiness (version skew, including the version.txt-ahead crash that
-# used to be checked here) is now Pulse's job, not Build's: PyAutoBuild is a
-# pure executor. The PyAutoAgent release agent gates on `pyauto-pulse readiness`
-# before invoking this script; a human running pre_build directly is trusted to
-# have checked `pyauto-pulse readiness` themselves.
+# used to be checked here) is now Heart's job, not Build's: PyAutoBuild is a
+# pure executor. The release agent gates on `pyauto-heart readiness` before
+# invoking this script; a human running pre_build directly is trusted to have
+# checked `pyauto-heart readiness` themselves.
 
 # Trigger the GitHub Actions release workflow
 echo ""
 echo "=== Triggering release workflow (minor_version=$MINOR_VERSION) ==="
-EXTRA_FIELDS=()
-if [ -n "$SKIP_SCRIPTS" ]; then
-    EXTRA_FIELDS+=(--field "skip_scripts=$SKIP_SCRIPTS")
-fi
-if [ -n "$SKIP_NOTEBOOKS" ]; then
-    EXTRA_FIELDS+=(--field "skip_notebooks=$SKIP_NOTEBOOKS")
-fi
 gh workflow run release.yml \
     --repo PyAutoLabs/PyAutoBuild \
     --field minor_version="$MINOR_VERSION" \
-    --field skip_release="$SKIP_RELEASE" \
-    "${EXTRA_FIELDS[@]}"
+    --field skip_release="$SKIP_RELEASE"
 
 echo ""
 echo "Pre-build complete. Workflow dispatched."

--- a/pre_build.sh
+++ b/pre_build.sh
@@ -3,14 +3,16 @@
 # for all workspace repos, then commit & push PyAutoBuild, then trigger
 # the GitHub Actions release workflow.
 #
-# Usage: bash pre_build.sh [minor_version] [skip_release]
+# Usage: bash pre_build.sh [minor_version]
 #   minor_version  Minor version suffix (default: 1)
-#   skip_release   Whether to skip the release stage, true or false (default: false)
+#
+# pre_build always dispatches a full real release. To build + publish to
+# TestPyPI without releasing (e.g. the Heart/Brain validation gate), dispatch
+# release.yml directly with rehearsal=true instead.
 
 set -e
 
 MINOR_VERSION="${1:-1}"
-SKIP_RELEASE="${2:-false}"
 
 # Resolve PYAUTOBASE from this script's location (same idiom as bin/autobuild)
 # so pre_build.sh works from any checkout — Linux, WSL, anywhere.
@@ -121,8 +123,7 @@ echo ""
 echo "=== Triggering release workflow (minor_version=$MINOR_VERSION) ==="
 gh workflow run release.yml \
     --repo PyAutoLabs/PyAutoBuild \
-    --field minor_version="$MINOR_VERSION" \
-    --field skip_release="$SKIP_RELEASE"
+    --field minor_version="$MINOR_VERSION"
 
 echo ""
 echo "Pre-build complete. Workflow dispatched."


### PR DESCRIPTION
## What & why

M1 of the Brain→Health→Heart release-validation redesign
(`PyAutoMind/feature/pyautobuild/release_yml_testpypi_rehearsal_mode.md`), plus a
cleanup of `release.yml`'s dispatch surface that the redesign makes possible.

### 1. TestPyPI-only "rehearsal" mode (the M1 deliverable)

A `rehearsal` `workflow_dispatch` input that builds every package from current source,
publishes to TestPyPI, and then **STOPS** — no PyPI upload, no git tag, no `tag_and_merge`,
no notebook generation/commit, no Colab-URL bumps. It unblocks the Heart release-validation
gate (M2) by letting Heart validate built **wheels** rather than source checkouts — the only
thing that catches packaging-layer bugs (the PyAutoFit `[nss]` `git+` direct-URL break and the
nufftax/JAX dependency-floor bug both slipped past source-based validation).

- **New `rehearsal` input** (default `false`); the full-release path is unchanged and default.
- **Unique per-run dev version in rehearsal** — `version_number` appends a PEP 440 dev segment
  (`….dev<run_number*100+run_attempt>`) so each dispatch publishes a fresh, distinct version.
  Dodges TestPyPI's duplicate-filename rejection *and* guarantees the rehearsed wheels reflect
  *this* run's source (a bare `--skip-existing` would silently keep stale wheels).
- **`--skip-existing` on the TestPyPI `twine upload`** to tolerate re-run attempts.
- **Pre-upload direct-reference-URL guard** — inspects each built wheel/sdist's metadata for
  PEP 508 direct-reference deps (`pkg @ git+…`) and fails loudly, naming the offender —
  surfacing the `[nss]` footgun early instead of as a raw twine HTTP 400.
- **New `rehearsal_version` job** emits the resolved version as a `testpypi-rehearsal-version`
  artifact (`testpypi_version.txt` + `rehearsal.json`) plus a job summary. Gated on
  `release_test_pypi`, so the artifact exists **iff** all five wheels built/uploaded/installed.
- **Downstream halt** — `release` and `run_smoke_tests` gate off in rehearsal; the rest
  cascade-skip via their dependency on `release`.

**Validated on live infra:** rehearsal run #645 published `autoconf/autoarray/autofit/autogalaxy/autolens == 2026.6.30.1.dev64501` to TestPyPI, emitted the artifact, passed the direct-URL guard on all five (incl. PyAutoFit), and skipped every release/notebook/Colab job.

### 2. Dispatch-surface cleanup (Heart/Build split follow-up)

With Build now a pure executor and rehearsal mode covering "build without releasing", the old
force-through knobs are dead weight:

- **Removed `skip_scripts` / `skip_notebooks`** — they gated the old `run_scripts`/`run_notebooks`
  matrices, which migrated to PyAutoHeart, leaving the inputs as no-ops.
- **Removed `skip_release`** — it was the old "build + push to TestPyPI but spin the release jobs
  as empty no-ops" dry-run; rehearsal does that better. Stripped from every job/step condition
  (job-level gates collapse to the rehearsal switch; standalone step gates drop so a non-rehearsal
  dispatch is always a full real release).
- **Removed `update_notebook_visualisations`** and the `run_notebooks_and_release_workspaces` job
  it gated — the inline notebook-visualisation render/commit path is defunct.
- **`pre_build.sh`** no longer takes/forwards `skip_release` or the `SKIP_SCRIPTS`/`SKIP_NOTEBOOKS`
  env vars; it always dispatches a full real release.
- **Renamed stale `Pulse` → `Heart`** and **`PyAutoAgent` → `PyAutoBrain`** across `release.yml`,
  `pre_build.sh`, `CLAUDE.md`, `AGENTS.md`, `README.md` (incl. the `Brain → Heart → Build` call
  chain). Verified against the PyAutoHeart repo that Heart owns `readiness`, `version_skew`,
  `url_check`, `verify_install`, and `workspace-validation.yml`.

**Resulting dispatch surface:** just `minor_version` + `rehearsal`. One mode switch — `false`
(default) is a full real release, `true` is TestPyPI-only validation.

## Validation

- `release.yml` parses; job graph verified — in rehearsal only `version_number`,
  `release_test_pypi`, `rehearsal_version` run; everything else skips. Confirmed end-to-end by
  run #645.
- `pytest` green (70 passed). `pre_build.sh` passes `bash -n`.
- No residual `pulse` / `skip_release` / `PyAutoAgent` / removed-flag references repo-wide
  (outside the intentional "these were removed" notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)