### PR TITLE
aggregate_results: preserve project/directory on failure/skip entries

### DIFF
--- a/autobuild/aggregate_results.py
+++ b/autobuild/aggregate_results.py
@@ -215,7 +215,7 @@ def _clean_result(r: dict) -> dict:
     for cross-run grouping; keeping them (renamed, without the underscore) means
     consumers of ``failures`` / ``skipped`` (e.g. PyAutoHeart's stage-report
     reshaping) don't lose which workspace a failure came from, matching what
-    ``slowest`` already re-attaches by hand below.
+    ``slowest`` (defined above in this file) already re-attaches by hand.
     """
     out = {k: v for k, v in r.items() if not k.startswith("_")}
     if "_project" in r:

--- a/autobuild/aggregate_results.py
+++ b/autobuild/aggregate_results.py
@@ -209,8 +209,20 @@ def aggregate(results_dir: Path) -> dict:
 
 
 def _clean_result(r: dict) -> dict:
-    """Remove internal keys from a result dict."""
-    return {k: v for k, v in r.items() if not k.startswith("_")}
+    """Strip internal keys from a result dict, surfacing project/directory as public fields.
+
+    ``_project`` / ``_directory`` are stamped onto every result in ``aggregate()``
+    for cross-run grouping; keeping them (renamed, without the underscore) means
+    consumers of ``failures`` / ``skipped`` (e.g. PyAutoHeart's stage-report
+    reshaping) don't lose which workspace a failure came from, matching what
+    ``slowest`` already re-attaches by hand below.
+    """
+    out = {k: v for k, v in r.items() if not k.startswith("_")}
+    if "_project" in r:
+        out["project"] = r["_project"]
+    if "_directory" in r:
+        out["directory"] = r["_directory"]
+    return out
 
 
 def generate_markdown(report: dict) -> str:

--- a/tests/test_aggregate_slowest.py
+++ b/tests/test_aggregate_slowest.py
@@ -108,3 +108,33 @@ def test_per_project_duration_aggregated(tmp_path, monkeypatch):
 
     report = aggregate_results.aggregate(tmp_path)
     assert report["per_project_duration_seconds"] == {"autofit": 3.5}
+
+
+def test_failures_and_skipped_carry_project_and_directory(tmp_path, monkeypatch):
+    """_clean_result() must surface project/directory as public fields on
+    failures/skipped entries (not just internally for grouping) — downstream
+    consumers like PyAutoHeart's stage-report reshaping key off them.
+    Copilot review finding on PyAutoBuild#112: this behaviour shipped
+    untested."""
+    monkeypatch.setattr(aggregate_results, "fetch_merged_prs", lambda: [])
+    _write_run_json(
+        tmp_path,
+        "autolens",
+        [
+            {"file": "scripts/imaging/a.py", "status": "failed", "duration_seconds": 1.0,
+             "error_message": "boom"},
+            {"file": "scripts/imaging/b.py", "status": "skipped", "duration_seconds": 0.0,
+             "skip_reason": "no data"},
+        ],
+    )
+
+    report = aggregate_results.aggregate(tmp_path)
+
+    assert len(report["failures"]) == 1
+    assert report["failures"][0]["project"] == "autolens"
+    assert report["failures"][0]["directory"] == "scripts/imaging"
+    assert report["failures"][0]["file"] == "scripts/imaging/a.py"
+
+    assert len(report["skipped"]) == 1
+    assert report["skipped"][0]["project"] == "autolens"
+    assert report["skipped"][0]["directory"] == "scripts/imaging"


### PR DESCRIPTION
## Summary

- `_clean_result()` stripped every `_`-prefixed internal key, so `failures` /
  `skipped` entries in `report.json` carried no workspace attribution —
  `slowest` already worked around this by manually re-attaching `project`
  after cleaning.
- Now `_clean_result()` also surfaces `_project`/`_directory` as public
  `project`/`directory` fields (additive only — no existing keys removed or
  renamed).
- Needed by PyAutoHeart PR #25 (M3 of the Brain→Health→Heart
  release-validation redesign): its new `heart/validate.py::to_stage_report()`
  reshapes this `report.json` into a stage report and needs per-failure
  `project` attribution.

## Test plan

- [x] `pytest tests/` — 70 passed (existing `test_aggregate_slowest.py`
      coverage unaffected; the change is additive)
- [x] Manual check: `aggregate()` on a small fixture now returns
      `{"file": ..., "project": ..., "directory": ..., ...}` for `failures`/
      `skipped` entries


---
_Generated by [Claude Code](https://claude.ai/code/session_01V4xvQJFsdgi2DtSdF89EqX)_