### PR TITLE
ci: pause routine scheduled (cron) workflow runs

### DIFF
--- a/.github/workflows/python_matrix.yml
+++ b/.github/workflows/python_matrix.yml
@@ -2,8 +2,9 @@ name: Python Version Matrix
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 3 * * 1'  # Monday 03:00 UTC, off-cycle from the daily release
+  # --- PAUSED 2026-07-06: routine cron disabled org-wide; re-enable by uncommenting ---
+  # schedule:
+  #   - cron: '0 3 * * 1'  # Monday 03:00 UTC, off-cycle from the daily release
 
 # Force local editable builds to outrank PyPI versions so pip's resolver
 # doesn't replace `pip install -e ./PyAutoConf` (1.0.dev0) with PyPI's

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: PyAuto Release
 
 on:
-  schedule:
-    - cron: '0 2 * * 1-5'  # 2 AM UTC weekdays
+  # --- PAUSED 2026-07-06: routine cron disabled org-wide; re-enable by uncommenting ---
+  # schedule:
+  #   - cron: '0 2 * * 1-5'  # 2 AM UTC weekdays
   workflow_dispatch:
     inputs:
       minor_version:


### PR DESCRIPTION
## Summary

Pauses all routine **scheduled (cron)** workflow runs across the org for now. The `schedule:` trigger in each routine workflow is commented out (not deleted) so the infrastructure stays fully in place and re-enabling is a one-line uncomment of the marked block.

Prompted by recurring GitHub failure emails from the daily release pushing version-bump commits to each library, which fired now-stale test runs. Rather than chase individual green-ness, the decision was to quiet all cron noise until we revisit.

## What's preserved

Every workflow file remains, and every non-cron trigger is kept, so all workflows stay manually runnable:

- `workflow_dispatch` (manual "Run workflow" button)
- `workflow_call` (reusable-workflow callers)
- `pull_request` (PR-time gating)

`nss_install_smoke.yml` gains a `workflow_dispatch:` so it too stays hand-runnable after its cron is paused.

## Note

For PyAutoBuild: this pauses the **scheduled** production release (weekdays 02:00 UTC). Releases can still be triggered manually via `workflow_dispatch`. No PyPI/tagging behaviour is otherwise changed.

Each paused block is marked `# --- PAUSED 2026-07-06: routine cron disabled org-wide; re-enable by uncommenting ---`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)