### PR TITLE
Note repo-list identity check against PyAutoMind/repos.yaml

### DIFF
--- a/pre_build.sh
+++ b/pre_build.sh
@@ -83,6 +83,8 @@ run_workspace() {
 # Positional args: repo project [generate=true] [slam=false] [readme_pkg=""]
 # readme_pkg: when non-empty, the README's "<pkg> vYYYY.M.D.B" pin is bumped to
 # the new VERSION. Empty for workspaces with no README version pin.
+# The repo names are checked against PyAutoMind/repos.yaml (the body map) by
+# `repos_sync.py --check`; the flags are Build policy and live only here.
 run_workspace "autofit_workspace"                    "autofit"      true   false  PyAutoFit
 run_workspace "autogalaxy_workspace"                 "autogalaxy"   true   false  PyAutoGalaxy
 run_workspace "autolens_workspace"                   "autolens"     true   true   PyAutoLens


### PR DESCRIPTION
Comment-only: the `run_workspace` repo names are now drift-checked against `PyAutoMind/repos.yaml` — the body map (PyAutoLabs/PyAutoMind#36) — via `python3 PyAutoMind/scripts/repos_sync.py --check`. The black/generate/readme-pin flags are Build policy and stay here. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)