### PR TITLE
build: un-park cluster/modeling + cluster/start_here from no_run.yaml

### DIFF
--- a/autobuild/config/no_run.yaml
+++ b/autobuild/config/no_run.yaml
@@ -29,8 +29,6 @@ autolens:
 - hpc/example_cpu # HPC paths dont exist locally.
 - examples/searches # Test mode breaks search visualization.
 - data_fitting # Test mode breaks .fits file output
-- cluster/modeling # Cluster modeling is not maintained and test mode breaks it.
-- cluster/start_here # Cluster analysis is not maintained and test mode breaks it.
 - mass_stellar_dark/modeling # Requires CSE to be JAX enabled.
 - mass_stellar_dark/slam # Requires CSE to be JAX enabled.
 - shapelets/modeling # Issue with JAX, claude remind me about this when you next look at build.


### PR DESCRIPTION
## Summary

Un-parks `cluster/modeling` and `cluster/start_here` from `no_run.yaml` (companion to PyAutoLabs/autolens_workspace#250, issue PyAutoLabs/autolens_workspace#249). The "test mode breaks it" comments predate the library small-mode hooks (PointSolver short-circuit, grid caps): under the sweep's own env defaults both scripts now pass from a clean dataset regeneration in 24 s / 26 s (evidence on the issue). The workspace-side PR migrates the scripts to the canonical `should_simulate` guard and gates the Lenstool example's heavy legs.

## Validation checklist (--auto run)
- Env computed via `autobuild.env_config.build_env_for_script` (authoritative), timed runs on the issue
- [ ] Human: merge together with the workspace PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
