### PR TITLE
feat: inject Colab setup cell into every generated notebook

### DIFF
--- a/autobuild/build_util.py
+++ b/autobuild/build_util.py
@@ -30,6 +30,95 @@ def py_to_notebook(filename: Path):
     return new_filename
 
 
+# Projects whose generated notebooks receive the Colab setup cell. Must stay in
+# sync with the `_PROJECTS` registry in PyAutoConf's `autoconf/setup_colab.py` —
+# the injected cell calls `setup_colab.setup("<project>")` with this key.
+COLAB_PROJECTS = {
+    "autofit",
+    "autogalaxy",
+    "autolens",
+    "howtofit",
+    "howtogalaxy",
+    "howtolens",
+}
+
+COLAB_SETUP_MARKDOWN = """__Google Colab Setup__
+
+This cell sets up the environment when the notebook is run on Google Colab: it installs the
+required PyAuto packages, clones the workspace (configuration files and example datasets) and
+points the configuration at it. If you are running the notebook elsewhere (e.g. locally via
+your own installation) it does nothing, and you can run it safely.
+
+Colab tip: model-fits run much faster on a GPU — enable one via "Runtime" -> "Change runtime
+type" -> "Hardware accelerator" before running the notebook."""
+
+COLAB_SETUP_CODE = '''try:
+    import google.colab
+    import subprocess
+    import sys
+
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "autoconf", "--no-deps"]
+    )
+except ImportError:
+    pass
+
+from autoconf import setup_colab
+
+setup_colab.setup("{project}")'''
+
+
+def inject_colab_setup(notebook_path, project: str):
+    """
+    Prepend the standard Google Colab setup cell pair (markdown explainer +
+    code cell) to a generated notebook, so every published notebook can
+    bootstrap itself on Colab.
+
+    The cells are inserted after the notebook's leading markdown cell (the
+    script's intro docstring) so the title stays on top. Notebooks whose
+    source already calls ``setup_colab`` (hand-written setup sections) are
+    left untouched. Returns True if cells were injected.
+    """
+    import json
+
+    if project not in COLAB_PROJECTS:
+        raise ValueError(
+            f"inject_colab_setup: unknown project '{project}' — add it to "
+            f"COLAB_PROJECTS here and to the _PROJECTS registry in "
+            f"PyAutoConf's autoconf/setup_colab.py. Known: {sorted(COLAB_PROJECTS)}"
+        )
+
+    with open(notebook_path, "r") as f:
+        notebook = json.load(f)
+
+    cells = notebook["cells"]
+
+    for cell in cells:
+        if "setup_colab" in "".join(cell.get("source", [])):
+            return False
+
+    markdown_cell = {
+        "cell_type": "markdown",
+        "metadata": {},
+        "source": COLAB_SETUP_MARKDOWN.splitlines(keepends=True),
+    }
+    code_cell = {
+        "cell_type": "code",
+        "execution_count": None,
+        "metadata": {},
+        "outputs": [],
+        "source": COLAB_SETUP_CODE.format(project=project).splitlines(keepends=True),
+    }
+
+    insert_at = 1 if cells and cells[0]["cell_type"] == "markdown" else 0
+    cells[insert_at:insert_at] = [markdown_cell, code_cell]
+
+    with open(notebook_path, "w") as f:
+        json.dump(notebook, f, indent=1)
+
+    return True
+
+
 def uncomment_jupyter_magic(f):
     with open(f, "r") as sources:
         lines = sources.readlines()

--- a/autobuild/generate.py
+++ b/autobuild/generate.py
@@ -103,6 +103,7 @@ if __name__ == "__main__":
         start = time.time()
         try:
             notebook = build_util.py_to_notebook(start_here_file)
+            build_util.inject_colab_setup(notebook, project)
             os.system(f"git add -f {notebook}")
             if report is not None:
                 from result_collector import ScriptResult, Status
@@ -154,6 +155,7 @@ if __name__ == "__main__":
         else:
             try:
                 source_path = build_util.py_to_notebook(script_path)
+                build_util.inject_colab_setup(source_path, project)
                 copy_to_notebooks(source_path)
                 os.remove(source_path)
                 if report is not None:

--- a/autobuild/generate_autofit.py
+++ b/autobuild/generate_autofit.py
@@ -25,4 +25,5 @@ def generate_project_folders():
                 continue
 
             new_filename = build_util.py_to_notebook(python_file)
+            build_util.inject_colab_setup(new_filename, "autofit")
             os.system(f"git add -f {new_filename}")

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -111,7 +111,7 @@ All scripts in `autobuild/` are run from within a checked-out workspace director
 - **`script_matrix.py <project1> [project2 ...]`** — Outputs a JSON matrix of `{name, directory}` pairs for GitHub Actions matrix strategy
 - **`tag_and_merge.sh --version <version>`** — Commits pending changes and tags library repos (PyAutoConf, PyAutoFit, PyAutoArray, PyAutoGalaxy, PyAutoLens) for release
 - **`url_check`** — URL hygiene moved to PyAutoHeart (Heart owns all health checking). `autobuild url_check` is now a thin shim to `pyauto-heart url_check`; the ecosystem-wide sweep runs from PyAutoHeart's central `url-check.yml` workflow (replacing the old per-repo `url_check.yml` workflows). The runnable scripts live at `PyAutoHeart/heart/checks/url_check*.{sh,py}`.
-- **`bump_colab_urls.sh <new-tag>`** — Rewrites every `colab.research.google.com/github/PyAutoLabs/<repo>/blob/<old-tag>/...` URL in cwd to use `<new-tag>`, where `<repo>` is one of `autofit_workspace`, `autogalaxy_workspace`, `autolens_workspace`, `HowToGalaxy`, `HowToLens`. Called by the `release_workspaces` and `bump_library_colab_urls` jobs in `release.yml` so README/docs Colab links always pin to the just-released tag. Idempotent; skips URLs not in canonical PyAutoLabs/date-tagged form.
+- **`bump_colab_urls.sh <new-tag>`** — Rewrites every `colab.research.google.com/github/PyAutoLabs/<repo>/blob/<old-tag>/...` URL in cwd to use `<new-tag>`, where `<repo>` is one of `autofit_workspace`, `autogalaxy_workspace`, `autolens_workspace`, `HowToFit`, `HowToGalaxy`, `HowToLens`. Called by the `release_workspaces` and `bump_library_colab_urls` jobs in `release.yml` so README/docs Colab links always pin to the just-released tag. Idempotent; skips URLs not in canonical PyAutoLabs/date-tagged form.
 
 ## Architecture
 
@@ -121,7 +121,42 @@ All scripts in `autobuild/` are run from within a checked-out workspace director
 1. `add_notebook_quotes.py` transforms triple-quoted docstrings into `# %%` cell markers in a temp `.py` file
 2. `ipynb-py-convert` converts the temp file to `.ipynb`
 3. `build_util.uncomment_jupyter_magic()` restores commented-out Jupyter magic commands (e.g. `# %matplotlib` → `%matplotlib`)
-4. Generated notebooks are `git add -f`ed directly
+4. `build_util.inject_colab_setup()` prepends the standard Google Colab setup cell pair (see "Google Colab architecture" below)
+5. Generated notebooks are `git add -f`ed directly
+
+### Google Colab architecture
+
+Every published notebook must be runnable on Google Colab with zero local
+installation. Four pieces, spread over three organs plus PyAutoConf:
+
+1. **Runtime bootstrap** — `PyAutoConf/autoconf/setup_colab.py`. A `_PROJECTS`
+   registry (`autofit`, `autogalaxy`, `autolens`, `howtofit`, `howtogalaxy`,
+   `howtolens`) maps each notebook repo to its package stack, workspace repo
+   and Colab directory. `setup_colab.setup("<project>")` is a no-op outside
+   Colab; on Colab it pip-installs the stack (`--no-deps` — Colab ships the
+   scientific base), shallow-clones the workspace at the tag matching the
+   installed release (default branch as fallback) and points autoconf's
+   config/output paths at it.
+2. **Generation-time injection** — `build_util.inject_colab_setup(notebook,
+   project)`, called by `generate.py` / `generate_autofit.py` after every
+   py→ipynb conversion. It prepends a markdown explainer + code cell calling
+   `setup_colab.setup("<project>")`, immediately after the notebook's title
+   cell. Notebooks whose script already hand-writes a `setup_colab` call are
+   left untouched. `build_util.COLAB_PROJECTS` must stay in sync with the
+   PyAutoConf registry; an unknown project fails generation loudly. Coverage
+   is therefore guaranteed by construction — every generated notebook is
+   Colab-ready, with no per-script maintenance.
+3. **Release maintenance** — `bump_colab_urls.sh` (above) re-pins every
+   canonical Colab URL in READMEs/docs/notebooks to the just-released tag,
+   from the `release_workspaces` and `bump_library_colab_urls` jobs. Only
+   date-tagged `PyAutoLabs/<repo>` URLs are bumped — unpinned or wrong-owner
+   URLs are invisible to it, which is why Heart forbids them (next item).
+4. **Monitoring** — PyAutoHeart's central `url-check.yml` (weekly): the
+   offline guard (`heart/checks/url_check.sh`) forbids Colab URL forms that
+   rot (Binder, `Jammy2211` owner, `/blob/release/`, unpinned `/blob/main/`,
+   chapter paths pointing at workspace repos instead of the HowTo repos); the
+   live audit (`url_check_live.py`) converts Colab URLs to raw-GitHub form and
+   404-checks that each linked notebook actually exists at its pinned tag.
 
 ### Script Execution Order
 

--- a/tests/test_inject_colab_setup.py
+++ b/tests/test_inject_colab_setup.py
@@ -1,0 +1,116 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "autobuild"))
+
+import build_util
+
+
+def make_notebook(path, cells):
+    notebook = {
+        "cells": cells,
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 4,
+    }
+    path.write_text(json.dumps(notebook))
+    return path
+
+
+def markdown_cell(text):
+    return {"cell_type": "markdown", "metadata": {}, "source": [text]}
+
+
+def code_cell(text):
+    return {
+        "cell_type": "code",
+        "execution_count": None,
+        "metadata": {},
+        "outputs": [],
+        "source": [text],
+    }
+
+
+def test_injects_after_leading_markdown(tmp_path):
+    nb_path = make_notebook(
+        tmp_path / "example.ipynb",
+        [markdown_cell("Title\n====="), code_cell("import autolens as al")],
+    )
+
+    assert build_util.inject_colab_setup(nb_path, "autolens") is True
+
+    cells = json.loads(nb_path.read_text())["cells"]
+    assert len(cells) == 4
+    assert cells[0]["source"] == ["Title\n====="]
+    assert cells[1]["cell_type"] == "markdown"
+    assert "Google Colab Setup" in "".join(cells[1]["source"])
+    assert cells[2]["cell_type"] == "code"
+    assert 'setup_colab.setup("autolens")' in "".join(cells[2]["source"])
+    assert cells[3]["source"] == ["import autolens as al"]
+
+
+def test_injects_at_top_when_no_leading_markdown(tmp_path):
+    nb_path = make_notebook(
+        tmp_path / "example.ipynb", [code_cell("import autofit as af")]
+    )
+
+    assert build_util.inject_colab_setup(nb_path, "autofit") is True
+
+    cells = json.loads(nb_path.read_text())["cells"]
+    assert cells[0]["cell_type"] == "markdown"
+    assert 'setup_colab.setup("autofit")' in "".join(cells[1]["source"])
+
+
+def test_skips_notebook_with_hand_written_setup(tmp_path):
+    original = [
+        markdown_cell("Title"),
+        code_cell("from autoconf import setup_colab\nsetup_colab.for_autolens()"),
+    ]
+    nb_path = make_notebook(tmp_path / "start_here.ipynb", original)
+
+    assert build_util.inject_colab_setup(nb_path, "autolens") is False
+    assert json.loads(nb_path.read_text())["cells"] == original
+
+
+def test_idempotent(tmp_path):
+    nb_path = make_notebook(
+        tmp_path / "example.ipynb", [markdown_cell("Title"), code_cell("x = 1")]
+    )
+
+    assert build_util.inject_colab_setup(nb_path, "howtolens") is True
+    once = nb_path.read_text()
+    assert build_util.inject_colab_setup(nb_path, "howtolens") is False
+    assert nb_path.read_text() == once
+
+
+def test_all_projects_accepted(tmp_path):
+    for project in sorted(build_util.COLAB_PROJECTS):
+        nb_path = make_notebook(tmp_path / f"{project}.ipynb", [code_cell("x = 1")])
+        assert build_util.inject_colab_setup(nb_path, project) is True
+        cells = json.loads(nb_path.read_text())["cells"]
+        assert f'setup_colab.setup("{project}")' in "".join(cells[1]["source"])
+
+
+def test_unknown_project_raises(tmp_path):
+    nb_path = make_notebook(tmp_path / "example.ipynb", [code_cell("x = 1")])
+    with pytest.raises(ValueError, match="unknown project 'euclid'"):
+        build_util.inject_colab_setup(nb_path, "euclid")
+
+
+def test_output_is_valid_notebook_json(tmp_path):
+    nb_path = make_notebook(
+        tmp_path / "example.ipynb", [markdown_cell("Title"), code_cell("x = 1")]
+    )
+    build_util.inject_colab_setup(nb_path, "autogalaxy")
+
+    notebook = json.loads(nb_path.read_text())
+    assert notebook["nbformat"] == 4
+    for cell in notebook["cells"]:
+        assert isinstance(cell["source"], list)
+        assert all(isinstance(line, str) for line in cell["source"])
+    code = notebook["cells"][2]
+    assert code["outputs"] == []
+    assert code["execution_count"] is None


### PR DESCRIPTION
## Summary

Census (#124) found only 9 of 489 published notebooks carry a Colab setup cell, while docs/READMEs link 100+ notebooks to Colab — every other notebook dies on `ModuleNotFoundError`. This makes coverage structural: `build_util.inject_colab_setup(notebook, project)` prepends the standard setup cell pair (markdown explainer + `setup_colab.setup("<project>")` code cell) after the title cell of every notebook generated by `generate.py` / `generate_autofit.py`. Hand-written setups are detected and skipped; an unknown project fails generation loudly. At the next release, all notebooks regenerate Colab-ready with zero per-script maintenance.

Also documents the end-to-end Colab architecture (bootstrap → injection → URL bumper → Heart sweep) in `docs/internals.md`.

Part of PyAutoLabs/PyAutoBuild#124 (Colab maturity, phase 1).

**Release coupling:** merge together with the PyAutoConf registry PR (same branch name there) — the injected cell calls `setup_colab.setup()`, which ships in the next autoconf release; notebooks only regenerate at release time, so ordering is safe by construction.

## API Changes

None — internal changes only (notebook generation pipeline; no published package API).

## Test Plan
- [x] `python3 -m pytest tests/` — 78 passed (7 new in `test_inject_colab_setup.py`: placement after title cell, top placement without title, skip on hand-written setup, idempotency, all six projects, unknown-project error, valid nbformat JSON)
- [x] End-to-end locally: `py_to_notebook` + injection on `HowToLens/.../tutorial_1_grids_and_galaxies.py` (cells placed correctly) and skip verified on `autolens_workspace/.../imaging/start_here.py` (hand-written setup preserved)
- [ ] First CI exercise: next release's `generate_notebooks` jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
