### PR TITLE
fix: assistant API-baseline script path in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -629,7 +629,7 @@ jobs:
         # Belt-and-braces JAX install (same reason as the install steps above).
         pip install "jax>=0.7,<0.11" "jaxlib>=0.7,<0.11"
         pushd workspace
-        python3 work/audit_skill_apis.py --write-baseline
+        python3 autoassistant/audit_skill_apis.py --write-baseline
         git add wiki/core/api_audit_baseline.json
         git commit -m "Release $VERSION: regenerate API audit baseline" || true
         popd


### PR DESCRIPTION
One-line fix for the 2026.7.9.1 release's only pipeline failure: `release_workspaces(autolens_assistant)` called `work/audit_skill_apis.py`, which the assistant's template restructure moved to `autoassistant/audit_skill_apis.py`. Baseline output path unchanged; `wiki_currency_check` un-skips at the next release. Human-directed fix+merge (issue #127 thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)