### PR TITLE
PyAutoScientist Phase 1: README + to_do_list hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ __pycache__/
 .env
 .secrets
 test_results/
+to_do_list
+to_do_list/

--- a/README.md
+++ b/README.md
@@ -1,56 +1,26 @@
-# PyAutoBuild: PyAuto Build Server
+# PyAutoBuild
 
-PyAutoBuild is the **executor** of the PyAuto release ecosystem — it builds, tests and deploys, but runs no release-readiness checks (those belong to [PyAutoHeart](https://github.com/PyAutoLabs/PyAutoHeart); the [PyAutoBrain](https://github.com/PyAutoLabs/PyAutoBrain) release agent gates on `pyauto-heart readiness` before dispatching a release). See `AGENTS.md` for the boundary.
+The Hands of the PyAuto organism: the executor that packages, tags, builds
+notebooks, and releases the PyAuto libraries (PyAutoConf, PyAutoFit,
+PyAutoArray, PyAutoGalaxy, PyAutoLens) and their workspaces to PyPI. It
+runs no readiness checks and makes no gate decisions — those belong to
+[PyAutoHeart](https://github.com/PyAutoLabs/PyAutoHeart), whose verdict the
+[PyAutoBrain](https://github.com/PyAutoLabs/PyAutoBrain) release agent
+reads before dispatching a release here.
 
-This project performs automatic building, testing and deployment of projects in the PyAuto software family:
+Every operation is reachable through one dispatcher:
 
-- [PyAutoConf](https://github.com/PyAutoLabs/PyAutoConf)
-- [PyAutoFit](https://github.com/PyAutoLabs/PyAutoFit)
-- [PyAutoArray](https://github.com/PyAutoLabs/PyAutoArray)
-- [PyAutoGalaxy](https://github.com/PyAutoLabs/PyAutoGalay)
-- [PyAutoLens](https://github.com/PyAutoLabs/PyAutoLens)
-- [PyAutoCTI](https://github.com/PyAutoLabs/PyAutoCTI)
-
-It uses their associated workspaces:
-
-- [autofit_workspace](https://github.com/PyAutoLabs/autofit_workspace)
-- [autogalaxy_workspace](https://github.com/PyAutoLabs/autogalaxy_workspace)
-- [autolens_workspace](https://github.com/PyAutoLabs/autolens_workspace)
-
-And their test workspaces:
-
-- [autofit_workspace_test](https://github.com/PyAutoLabs/autofit_workspace_test)
-- [autogalaxy_workspace_test](https://github.com/PyAutoLabs/autogalaxy_workspace_test)
-- [autolens_workspace_test](https://github.com/PyAutoLabs/autolens_workspace_test)
-
-The build pipeline includes the following tasks:
-
-- Package and release all projects to the test_pypi server.
-- Install all test packages via pip.
-- Run all project unit tests.
-- Run all workspace integration test scripts.
-- If successful, release packages to pypi.
-- Update workspaces with new test scripts.
-
-This automatically runs every 24 hours.
-
-## CLI Usage
-
-Every operation is invokable from the shell via the `autobuild` dispatcher:
-
-```
-bash bin/autobuild help                    # list every subcommand
-bash bin/autobuild help <subcommand>       # full docstring for one
-bash bin/autobuild pre_build [minor]       # full pre-build flow
-bash bin/autobuild verify_install          # release-readiness gate
+```bash
+bash bin/autobuild help                # list every subcommand
+bash bin/autobuild help <subcommand>   # full docstring for one
+bash bin/autobuild pre_build [minor]   # format, generate notebooks, bump, push
+bash bin/autobuild run_all             # run the workspace validation scripts
 ```
 
-Recommended alias for `~/.bashrc`:
+The release pipeline (`.github/workflows/release.yml`) packages to
+TestPyPI, verifies the install, runs the workspace scripts, and on success
+releases to PyPI and tags the workspaces — nightly, when there is new
+activity to ship.
 
-```
-alias autobuild-help='$HOME/Code/PyAutoLabs/PyAutoBuild/bin/autobuild help'
-```
-
-The dispatcher wraps both bash scripts and Python tools, so any operation in
-this repo is reachable from a single entry point with consistent `--help`
-documentation.
+Boundary and agent guidance: [AGENTS.md](AGENTS.md). The organism:
+[PyAutoBrain/ORGANISM.md](https://github.com/PyAutoLabs/PyAutoBrain/blob/main/ORGANISM.md).

--- a/to_do_list
+++ b/to_do_list
@@ -1,4 +1,0 @@
-- Need to test different numpy, scipy, scikit-learn, threadpoolctl, joblib.
-- Tests using full dynesty runs with inversion, BrightnessImageNN pix, with parallel processing.
-- Workspace tagging.
-- Remove annoyinf report.log and root.log once and for all.


### PR DESCRIPTION
## Summary
PyAutoScientist Phase 1 (PyAutoBrain/issues/65): repo hygiene + presentable README, zero behaviour surface. (LICENSE already present — MIT since 2021.)

- Rewrite `README.md` from 56 lines to 26 human-written lines: the executor role and boundary, the `autobuild` dispatcher, the release pipeline in one paragraph. Also drops the long-stale "PyAutoGalay" typo'd link and the PyAutoCTI row.
- Evacuate `to_do_list` (4 stale personal notes, committed instance run-state that would collide with any fork): content preserved in `PyAutoMind/ideas.md` (companion PR), file removed and gitignored. `test_results/` was already gitignored and untracked — the assessment's "committed" claim was stale on that half.

No diffs to autobuild/ code, pre_build.sh, or workflows beyond `.gitignore`.

## API Changes
None — documentation and hygiene only.

## Test Plan
- [x] `pytest tests/` — 78 passed
- [x] `repos_sync.py --check` green (pre_build.sh table untouched)

Part of the 5-PR Phase 1 set (Brain, Mind, Heart, Memory, Build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
