### PR TITLE
PyAutoScientist Phase 2: CONTRIBUTING + README RTD link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+PyAutoBuild is an organ of **PyAutoScientist** — a living reference implementation
+that is the maintainer's daily working system. `main` moves fast and
+carries **no compatibility promises**: adopt by fork-and-pull (confining
+your diff to the declared config surfaces), never by tracking, and pin what
+you depend on. Issues and PRs are welcome; triage pace is set by the live
+instance's needs.
+
+The full contribution and stability policy is
+[PyAutoBrain/CONTRIBUTING.md](https://github.com/PyAutoLabs/PyAutoBrain/blob/main/CONTRIBUTING.md);
+the adoption model is documented at <https://pyautoscientist.readthedocs.io>.

--- a/README.md
+++ b/README.md
@@ -23,4 +23,5 @@ releases to PyPI and tags the workspaces — nightly, when there is new
 activity to ship.
 
 Boundary and agent guidance: [AGENTS.md](AGENTS.md). The organism:
-[PyAutoBrain/ORGANISM.md](https://github.com/PyAutoLabs/PyAutoBrain/blob/main/ORGANISM.md).
+[PyAutoBrain/ORGANISM.md](https://github.com/PyAutoLabs/PyAutoBrain/blob/main/ORGANISM.md),
+documented in full at <https://pyautoscientist.readthedocs.io>.


### PR DESCRIPTION
## Summary
PyAutoScientist Phase 2 (PyAutoBrain/issues/68): `CONTRIBUTING.md` (stability disclaimer — living reference implementation, fork-and-pull, no compatibility promises; points at the canonical policy in PyAutoBrain) and the README RTD link line (https://pyautoscientist.readthedocs.io).

## API Changes
None — documentation only.

## Test Plan
- [x] `repos_sync.py --check` green on the branch set

Part of the 6-PR Phase 2 set (Brain, Mind, Heart, Memory, Build, hub). Human leg after the set merges: import the pyautoscientist RTD project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
