### PR TITLE
PyAutoScientist 3b-4a: Build run matrix → workspaces.yaml

### DIFF
--- a/autobuild/config/workspaces.yaml
+++ b/autobuild/config/workspaces.yaml
@@ -1,0 +1,26 @@
+# The workspace run matrix — Build POLICY (which repos the validation
+# pipeline runs, under which short key, and which are slow-skip audited).
+# Repo IDENTITY must match PyAutoMind/repos.yaml (the body map);
+# repos_sync.py --check flags drift. An adopter replaces this file.
+#
+# run_all: short key -> {repo, report}: `autobuild run_all <key>` runs
+# <repo>'s scripts and writes reports under <report>.
+run_all:
+  autofit: {repo: autofit_workspace, report: autofit}
+  autogalaxy: {repo: autogalaxy_workspace, report: autogalaxy}
+  autolens: {repo: autolens_workspace, report: autolens}
+  autofit_test: {repo: autofit_workspace_test, report: autofit_test}
+  autogalaxy_test: {repo: autogalaxy_workspace_test, report: autogalaxy_test}
+  autolens_test: {repo: autolens_workspace_test, report: autolens_test}
+  howtofit: {repo: HowToFit, report: howtofit}
+  howtogalaxy: {repo: HowToGalaxy, report: howtogalaxy}
+  howtolens: {repo: HowToLens, report: howtolens}
+  euclid: {repo: euclid_strong_lens_modeling_pipeline, report: euclid}
+
+# slow_skip_check: the default audit targets when none are given on the CLI.
+slow_skip_default:
+  - autofit_workspace
+  - autogalaxy_workspace
+  - autolens_workspace
+  - autofit_workspace_test
+  - autolens_workspace_test

--- a/autobuild/run_all.py
+++ b/autobuild/run_all.py
@@ -32,18 +32,19 @@ AUTOBUILD_DIR = Path(__file__).parent
 PYAUTOBASE = AUTOBUILD_DIR.parent.parent  # PyAutoLabs/
 RESULTS_BASE = AUTOBUILD_DIR.parent / "test_results"
 
-WORKSPACES = {
-    "autofit": ("autofit_workspace", "autofit"),
-    "autogalaxy": ("autogalaxy_workspace", "autogalaxy"),
-    "autolens": ("autolens_workspace", "autolens"),
-    "autofit_test": ("autofit_workspace_test", "autofit_test"),
-    "autogalaxy_test": ("autogalaxy_workspace_test", "autogalaxy_test"),
-    "autolens_test": ("autolens_workspace_test", "autolens_test"),
-    "howtofit": ("HowToFit", "howtofit"),
-    "howtogalaxy": ("HowToGalaxy", "howtogalaxy"),
-    "howtolens": ("HowToLens", "howtolens"),
-    "euclid": ("euclid_strong_lens_modeling_pipeline", "euclid"),
-}
+def _load_workspaces() -> dict:
+    """The run matrix, from autobuild/config/workspaces.yaml (Build policy).
+    Strict: the file is in-repo and load-bearing — fail loudly if absent."""
+    import yaml
+
+    cfg = yaml.safe_load((AUTOBUILD_DIR / "config" / "workspaces.yaml").read_text())
+    return {
+        key: (spec["repo"], spec["report"])
+        for key, spec in cfg["run_all"].items()
+    }
+
+
+WORKSPACES = _load_workspaces()
 
 DEFAULT_TIMEOUT_SECS = 300
 

--- a/autobuild/slow_skip_check.py
+++ b/autobuild/slow_skip_check.py
@@ -243,15 +243,12 @@ def format_report_section(
 if __name__ == "__main__":
     import sys
     pyautobase = Path(__file__).resolve().parent.parent.parent
-    default_workspaces = [
-        pyautobase / name for name in (
-            "autofit_workspace",
-            "autogalaxy_workspace",
-            "autolens_workspace",
-            "autofit_workspace_test",
-            "autolens_workspace_test",
-        )
-    ]
+    import yaml
+
+    cfg = yaml.safe_load(
+        (Path(__file__).resolve().parent / "config" / "workspaces.yaml").read_text()
+    )
+    default_workspaces = [pyautobase / name for name in cfg["slow_skip_default"]]
     targets = [Path(p) for p in sys.argv[1:]] or default_workspaces
     slow = find_slow_skips(targets)
     needs_fix = find_needs_fix_skips(targets)


### PR DESCRIPTION
## Summary
Heart#53 (config extraction, 4a): the run matrix (`run_all.py` `WORKSPACES`) and `slow_skip_check.py`'s default audit list move to a new `autobuild/config/workspaces.yaml` (Build policy, body-map-checked identity, adopter-replaceable). Both scripts load it strictly. Matrix verified identical (10 keys); suite green; slow_skip_check exercised end-to-end.

## API Changes
None — `run_all.WORKSPACES` keeps its name and shape (now loaded from config).

## Test Plan
- [x] `pytest tests/` — 78 passed
- [x] `run_all.WORKSPACES` loads with the identical 10-key mapping
- [x] `slow_skip_check.py` runs on the config-driven defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)