### PR TITLE
docs: human-led natural-language tone sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ notebooks, and releases the PyAuto libraries (PyAutoConf, PyAutoFit,
 PyAutoArray, PyAutoGalaxy, PyAutoLens) and their workspaces to PyPI. It
 runs no readiness checks and makes no gate decisions — those belong to
 [PyAutoHeart](https://github.com/PyAutoLabs/PyAutoHeart), whose verdict the
-[PyAutoBrain](https://github.com/PyAutoLabs/PyAutoBrain) release agent
-reads before dispatching a release here.
+[PyAutoBrain](https://github.com/PyAutoLabs/PyAutoBrain) release agent, under
+the human lead's direction, reads before dispatching a release here.
 
 Every operation is reachable through one dispatcher:
 


### PR DESCRIPTION
Part of the human-led tone sweep — PyAutoLabs/PyAutoBrain#81. Rewords the organism framing to the voice settled on the [org front page](https://github.com/PyAutoLabs): you lead in plain English, agents plan/build/test/release, you make every judgment call. Tone only — no boundary or contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)